### PR TITLE
Add sort command to order transactions

### DIFF
--- a/src/main/java/seedu/duke/command/SortCommand.java
+++ b/src/main/java/seedu/duke/command/SortCommand.java
@@ -1,0 +1,67 @@
+package seedu.duke.command;
+
+import seedu.duke.MoneyBagProMaxException;
+import seedu.duke.transaction.Transaction;
+import seedu.duke.transactionlist.TransactionList;
+import seedu.duke.ui.Ui;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Sorts and displays transactions by the given criteria (date, amount, or category).
+ * The original list order is not modified.
+ */
+public class SortCommand extends Command {
+    private final String sortBy;
+
+    /**
+     * Creates a SortCommand with the given sort criteria.
+     *
+     * @param sortBy the field to sort by ("date", "amount", or "category")
+     */
+    public SortCommand(String sortBy) {
+        assert sortBy != null : "Sort criteria should not be null";
+        this.sortBy = sortBy;
+    }
+
+    /**
+     * Sorts transactions by the stored criteria and displays the sorted list.
+     * Does not modify the original transaction list order.
+     *
+     * @param list the transaction list to sort and display
+     * @param ui   the ui instance for output
+     * @throws MoneyBagProMaxException if the sort criteria is invalid
+     */
+    @Override
+    public void execute(TransactionList list, Ui ui) throws MoneyBagProMaxException {
+        assert list != null : "TransactionList should not be null";
+
+        if (list.isEmpty()) {
+            ui.showMessage("No transactions found.");
+            return;
+        }
+
+        Comparator<Transaction> comparator;
+        switch (sortBy) {
+        case "date":
+            comparator = Comparator.comparing(Transaction::getDate);
+            break;
+        case "amount":
+            comparator = Comparator.comparingDouble(Transaction::getAmount).reversed();
+            break;
+        case "category":
+            comparator = Comparator.comparing(Transaction::getCategory, String.CASE_INSENSITIVE_ORDER);
+            break;
+        default:
+            throw new MoneyBagProMaxException(
+                    "Invalid sort criteria. Use: sort by/date, sort by/amount, or sort by/category");
+        }
+
+        List<Transaction> sorted = list.getSortedList(comparator);
+        ui.showMessage("Transactions sorted by " + sortBy + ":");
+        for (int i = 0; i < sorted.size(); i++) {
+            ui.showMessage((i + 1) + ". " + sorted.get(i));
+        }
+    }
+}

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -9,6 +9,7 @@ import seedu.duke.command.ListCommand;
 import seedu.duke.command.SummaryCommand;
 import seedu.duke.command.HelpCommand;
 import seedu.duke.command.FindCommand;
+import seedu.duke.command.SortCommand;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
@@ -51,6 +52,8 @@ public class Parser {
                 throw new MoneyBagProMaxException("Please provide a keyword to search for.");
             }
             return new FindCommand(arguments);
+        case "sort":
+            return parseSortCommand(arguments);
         default:
             throw new MoneyBagProMaxException("Unknown command. Type `help` to see the list of available commands.");
         }
@@ -157,5 +160,27 @@ public class Parser {
         } catch (DateTimeParseException e) {
             throw new MoneyBagProMaxException("Invalid date format — expected yyyy-MM-dd. Using today's date.");
         }
+    }
+
+    /**
+     * Parses the arguments for the sort command.
+     * Validates the "by/" prefix and the sort criteria value.
+     *
+     * @param args the argument string after "sort", e.g. "by/date"
+     * @return a new SortCommand with the parsed criteria
+     * @throws MoneyBagProMaxException if the format or criteria is invalid
+     */
+    private Command parseSortCommand(String args) throws MoneyBagProMaxException {
+        String sortPrefix = "by/";
+        if (args.isEmpty() || !args.startsWith(sortPrefix)) {
+            throw new MoneyBagProMaxException(
+                    "Invalid format. Use: sort by/date, sort by/amount, or sort by/category");
+        }
+        String sortBy = args.substring(sortPrefix.length()).trim().toLowerCase();
+        if (!sortBy.equals("date") && !sortBy.equals("amount") && !sortBy.equals("category")) {
+            throw new MoneyBagProMaxException(
+                    "Invalid sort criteria. Use: sort by/date, sort by/amount, or sort by/category");
+        }
+        return new SortCommand(sortBy);
     }
 }

--- a/src/main/java/seedu/duke/transactionlist/TransactionList.java
+++ b/src/main/java/seedu/duke/transactionlist/TransactionList.java
@@ -3,6 +3,8 @@ package seedu.duke.transactionlist;
 import seedu.duke.transaction.Transaction;
 
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.logging.Logger;
 
 /**
@@ -75,5 +77,18 @@ public class TransactionList {
         logger.info("Removing transaction at index: " + i);
         return transactions.remove(i);
     }
-    // todo contain/find
+
+    /**
+     * Returns a new list containing all transactions sorted by the given comparator.
+     * The original list order is not modified.
+     *
+     * @param comparator the comparator to determine sort order
+     * @return a new sorted list of transactions
+     */
+    public List<Transaction> getSortedList(Comparator<Transaction> comparator) {
+        assert comparator != null : "Comparator should not be null";
+        ArrayList<Transaction> sorted = new ArrayList<>(transactions);
+        sorted.sort(comparator);
+        return sorted;
+    }
 }

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -41,10 +41,14 @@ public class Ui {
                                  - Shows overall totals or specific category totals.
                                  - Valid types: `all`, `expense`, `income`, or specific categories.
                                  - Example: summary all
-                6. Delete      : `delete [ENTRY INDEX]`
+                6. Sort        : `sort by/[CRITERIA]`
+                                 - Sorts and displays transactions by the given criteria.
+                                 - Valid criteria: `date`, `amount`, `category`
+                                 - Example: sort by/date
+                7. Delete      : `delete [ENTRY INDEX]`
                                  - Deletes a transaction using its number from the `list`.
                                  - Example: delete 3
-                7. Exit        : `exit`
+                8. Exit        : `exit`
                                  - Exits the program.
                 %s""".formatted(separator, separator, separator);
 

--- a/src/test/java/seedu/duke/command/SortCommandTest.java
+++ b/src/test/java/seedu/duke/command/SortCommandTest.java
@@ -1,0 +1,135 @@
+package seedu.duke.command;
+
+import seedu.duke.MoneyBagProMaxException;
+import seedu.duke.transaction.Expense;
+import seedu.duke.transaction.Income;
+import seedu.duke.transactionlist.TransactionList;
+import seedu.duke.ui.Ui;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SortCommandTest {
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+
+    @BeforeEach
+    public void setUpStreams() {
+        System.setOut(new PrintStream(outContent));
+    }
+
+    @AfterEach
+    public void restoreStreams() {
+        System.setOut(originalOut);
+    }
+
+    @Test
+    public void execute_sortByDate_printsChronologicalOrder() throws MoneyBagProMaxException {
+        TransactionList list = new TransactionList();
+        Ui ui = new Ui();
+
+        list.add(new Expense("food", 10.50, "lunch", LocalDate.parse("2026-03-16")));
+        list.add(new Income("salary", 50.00, "pay", LocalDate.parse("2026-03-14")));
+        list.add(new Expense("transport", 5.00, "bus", LocalDate.parse("2026-03-15")));
+
+        Command command = new SortCommand("date");
+        command.execute(list, ui);
+
+        String expectedOutput = "Transactions sorted by date:" + System.lineSeparator()
+                + "1. [Income] salary \"pay\" $50.00 (2026-03-14)" + System.lineSeparator()
+                + "2. [Expense] transport \"bus\" $5.00 (2026-03-15)" + System.lineSeparator()
+                + "3. [Expense] food \"lunch\" $10.50 (2026-03-16)" + System.lineSeparator();
+
+        assertEquals(expectedOutput, outContent.toString());
+    }
+
+    @Test
+    public void execute_sortByAmount_printsLargestFirst() throws MoneyBagProMaxException {
+        TransactionList list = new TransactionList();
+        Ui ui = new Ui();
+
+        list.add(new Expense("food", 10.50, "lunch", LocalDate.parse("2026-03-14")));
+        list.add(new Income("salary", 50.00, "pay", LocalDate.parse("2026-03-14")));
+        list.add(new Expense("transport", 5.00, "bus", LocalDate.parse("2026-03-14")));
+
+        Command command = new SortCommand("amount");
+        command.execute(list, ui);
+
+        String expectedOutput = "Transactions sorted by amount:" + System.lineSeparator()
+                + "1. [Income] salary \"pay\" $50.00 (2026-03-14)" + System.lineSeparator()
+                + "2. [Expense] food \"lunch\" $10.50 (2026-03-14)" + System.lineSeparator()
+                + "3. [Expense] transport \"bus\" $5.00 (2026-03-14)" + System.lineSeparator();
+
+        assertEquals(expectedOutput, outContent.toString());
+    }
+
+    @Test
+    public void execute_sortByCategory_printsAlphabeticalOrder() throws MoneyBagProMaxException {
+        TransactionList list = new TransactionList();
+        Ui ui = new Ui();
+
+        list.add(new Expense("transport", 5.00, "bus", LocalDate.parse("2026-03-14")));
+        list.add(new Expense("food", 10.50, "lunch", LocalDate.parse("2026-03-14")));
+        list.add(new Income("salary", 50.00, "pay", LocalDate.parse("2026-03-14")));
+
+        Command command = new SortCommand("category");
+        command.execute(list, ui);
+
+        String expectedOutput = "Transactions sorted by category:" + System.lineSeparator()
+                + "1. [Expense] food \"lunch\" $10.50 (2026-03-14)" + System.lineSeparator()
+                + "2. [Income] salary \"pay\" $50.00 (2026-03-14)" + System.lineSeparator()
+                + "3. [Expense] transport \"bus\" $5.00 (2026-03-14)" + System.lineSeparator();
+
+        assertEquals(expectedOutput, outContent.toString());
+    }
+
+    @Test
+    public void execute_emptyList_printsNoTransactions() throws MoneyBagProMaxException {
+        TransactionList list = new TransactionList();
+        Ui ui = new Ui();
+
+        Command command = new SortCommand("date");
+        command.execute(list, ui);
+
+        String expectedOutput = "No transactions found." + System.lineSeparator();
+        assertEquals(expectedOutput, outContent.toString());
+    }
+
+    @Test
+    public void execute_invalidCriteria_throwsException() {
+        TransactionList list = new TransactionList();
+        Ui ui = new Ui();
+
+        list.add(new Expense("food", 10.50, "lunch", LocalDate.parse("2026-03-14")));
+
+        Command command = new SortCommand("invalid");
+        assertThrows(MoneyBagProMaxException.class, () -> command.execute(list, ui));
+    }
+
+    @Test
+    public void execute_sortByDate_doesNotModifyOriginalList() throws MoneyBagProMaxException {
+        TransactionList list = new TransactionList();
+        Ui ui = new Ui();
+
+        Expense first = new Expense("food", 10.50, "lunch", LocalDate.parse("2026-03-16"));
+        Income second = new Income("salary", 50.00, "pay", LocalDate.parse("2026-03-14"));
+
+        list.add(first);
+        list.add(second);
+
+        Command command = new SortCommand("date");
+        command.execute(list, ui);
+
+        assertEquals(first, list.get(0));
+        assertEquals(second, list.get(1));
+    }
+}

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -1,5 +1,53 @@
 package seedu.duke.parser;
 
+import seedu.duke.MoneyBagProMaxException;
+import seedu.duke.command.Command;
+import seedu.duke.command.SortCommand;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 // structure of test names: methodToTest_input_expectedOutput
 class ParserTest {
+
+    @Test
+    public void parse_sortByDate_returnsSortCommand() throws MoneyBagProMaxException {
+        Parser parser = new Parser();
+        Command command = parser.parse("sort by/date");
+        assertInstanceOf(SortCommand.class, command);
+    }
+
+    @Test
+    public void parse_sortByAmount_returnsSortCommand() throws MoneyBagProMaxException {
+        Parser parser = new Parser();
+        Command command = parser.parse("sort by/amount");
+        assertInstanceOf(SortCommand.class, command);
+    }
+
+    @Test
+    public void parse_sortByCategory_returnsSortCommand() throws MoneyBagProMaxException {
+        Parser parser = new Parser();
+        Command command = parser.parse("sort by/category");
+        assertInstanceOf(SortCommand.class, command);
+    }
+
+    @Test
+    public void parse_sortNoArguments_throwsException() {
+        Parser parser = new Parser();
+        assertThrows(MoneyBagProMaxException.class, () -> parser.parse("sort"));
+    }
+
+    @Test
+    public void parse_sortInvalidCriteria_throwsException() {
+        Parser parser = new Parser();
+        assertThrows(MoneyBagProMaxException.class, () -> parser.parse("sort by/invalid"));
+    }
+
+    @Test
+    public void parse_sortMissingByPrefix_throwsException() {
+        Parser parser = new Parser();
+        assertThrows(MoneyBagProMaxException.class, () -> parser.parse("sort date"));
+    }
 }

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -50,10 +50,14 @@ Enter a command: ============================================================
                  - Shows overall totals or specific category totals.
                  - Valid types: `all`, `expense`, `income`, or specific categories.
                  - Example: summary all
-6. Delete      : `delete [ENTRY INDEX]`
+6. Sort        : `sort by/[CRITERIA]`
+                 - Sorts and displays transactions by the given criteria.
+                 - Valid criteria: `date`, `amount`, `category`
+                 - Example: sort by/date
+7. Delete      : `delete [ENTRY INDEX]`
                  - Deletes a transaction using its number from the `list`.
                  - Example: delete 3
-7. Exit        : `exit`
+8. Exit        : `exit`
                  - Exits the program.
 ============================================================
 Enter a command: [ERROR!] Unknown command. Type `help` to see the list of available commands.


### PR DESCRIPTION
## Summary
- Adds `sort` command with `sort by/date`, `sort by/amount`, `sort by/category` formats
- Displays transactions in sorted order without modifying the original list
- Date sorts ascending (chronological), amount sorts descending (largest first), category sorts alphabetically

Closes #66