### PR TITLE
docs: fix DG placeholder sections and component documentation

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -2,10 +2,13 @@
 
 ## Acknowledgements
 
-{list here sources of all reused/adapted ideas, code, documentation, and third-party libraries -- include links to the original source as well}
+This project builds on ideas and resources from the following sources:
 
-## Design & implementation
-
+- **[Duke](https://github.com/se-edu/duke)**: the CS2113 individual project (IP) codebase was built on top of Duke, a task manager project provided by the SE-EDU initiative. Core architectural patterns carried forward from Duke form the foundation of this project.
+- **[AddressBook Level-3 (AB3)](https://github.com/se-edu/addressbook-level3)**: project structure, command-pattern architecture, and Developer Guide format adapted from the SE-EDU initiative.
+- **Java SE 17 Documentation**: [`java.time.LocalDate`](https://docs.oracle.com/en/java/se/17/docs/api/java.base/java/time/LocalDate.html) and [`java.util.logging`](https://docs.oracle.com/en/java/se/17/docs/api/java.logging/java/util/logging/package-summary.html) API references used throughout the codebase.
+- **[PlantUML](https://plantuml.com/)**: all UML sequence and class diagrams in this guide were generated using PlantUML.
+- **CS2113 Teaching Team, National University of Singapore**: the individual project (IP) phase of CS2113 provided the foundational scaffolding and iterative development process that each team member independently built upon before this team project (TP). Special thanks to the course instructors for the structured guidance throughout both phases.
 # Design
 
 ## Architecture
@@ -14,8 +17,84 @@
 
 ## Components
 ### Parser
+The `Parser` component is responsible for interpreting raw user input and producing the
+appropriate `Command` object. It is constructed with a reference to `UndoRedoManager` and
+`RecurringTransactionList`, both of which are injected into commands that require them.
+
+Its single public entry point is `parse(String input)`, which splits the input on the first
+space to extract the command word and the remaining argument string, then dispatches via a
+`switch` statement to a private `parse*Command()` helper for each recognised command word.
+Unrecognised command words throw a `MoneyBagProMaxException` with a prompt to type `help`.
+
+Three private helper methods are shared across multiple `parse*Command()` calls to keep
+parsing logic consistent:
+
+| Helper                               | Description                                                                                                                        |
+|--------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| `parseAmount(String remainder)`      | Extracts the numeric token before any `desc/` or `d/` flag; throws `NumberFormatException` if non-numeric.                         |
+| `parseDescription(String remainder)` | Returns the value after `desc/` (up to the next flag), or an empty string if `desc/` is absent.                                    |
+| `parseDate(String remainder)`        | Returns the `LocalDate` after `d/`, or `LocalDate.now()` if `d/` is absent. Throws `MoneyBagProMaxException` on an invalid format. |
+
+#### Error Handling for Invalid Date Input
+When a `d/` flag is present, `parseDate()` calls `LocalDate.parse()` on the supplied token.
+The two possible outcomes are:
+
+| Scenario | Behaviour |
+|---|---|
+| `d/` flag is **omitted** | `parseDate()` returns `LocalDate.now()` — the transaction is created with today's date. |
+| `d/` flag is present with a **valid** date | `parseDate()` returns the parsed `LocalDate` — the transaction is created normally. |
+| `d/` flag is present with an **invalid** date | `LocalDate.parse()` throws `DateTimeParseException` → `parseDate()` throws `MoneyBagProMaxException` → the **entire command is rejected**. No transaction is created. |
+
+For example, entering `add food/10 d/2026-13-01` will display the error message and leave the
+transaction list unchanged.
+
+> ⚠️ **Known issue:** The error message currently reads
+> *"Invalid date format — expected yyyy-MM-dd. Using today's date."*
+> This is misleading — the application does **not** fall back to today's date on a bad format;
+> it rejects the command entirely. The trailing *"Using today's date."* clause should be removed.
+> Today's date is only used when the `d/` flag is **omitted entirely**, not when an invalid
+> value is supplied.
+
 ### Command
+The `Command` component defines the contract that every user action must satisfy. The abstract
+base class declares three methods that the main loop relies on:
+
+| Method                                 | Default  | Description                                                                                                            |
+|----------------------------------------|----------|------------------------------------------------------------------------------------------------------------------------|
+| `execute(TransactionList, Budget, Ui)` | abstract | Carries out the command's action; throws `MoneyBagProMaxException` on failure.                                         |
+| `isExit()`                             | `false`  | Returns `true` only in `ExitCommand`, signalling the main loop to terminate.                                           |
+| `isMutating()`                         | `false`  | Returns `true` if the command modifies `TransactionList`; triggers `Storage.save()` after execution.                   |
+| `isMutatingRecurring()`                | `false`  | Returns `true` if the command modifies `RecurringTransactionList`; triggers `Storage.saveRecurring()` after execution. |
+
+Every concrete command extends `Command` and overrides only the methods relevant to it.
+Commands that modify data (e.g. `AddCommand`, `DeleteCommand`, `EditCommand`) override
+`isMutating()` to return `true`. Commands that modify recurring templates (e.g.
+`AddRecurringCommand`, `DeleteRecurringCommand`, `GenerateRecurringCommand`) override
+`isMutatingRecurring()` to return `true`. Read-only commands (e.g. `ListCommand`,
+`SortCommand`, `FilterCommand`) inherit all three defaults and do not trigger any saves.
+
 ### Ui
+The `Ui` component handles all terminal input and output. It wraps a `Scanner` for reading
+lines and exposes dedicated methods that the rest of the application calls, so no other
+component writes to `System.out` directly.
+
+Key methods:
+
+| Method                                               | Description                                                                                                |
+|------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
+| `readInput()`                                        | Prints a yellow-coloured prompt and returns the next line from stdin.                                      |
+| `showMessage(String message)`                        | Prints a single message string; asserts the message is non-null.                                           |
+| `showList(TransactionList list)`                     | Prints all transactions numbered 1-based between dividers, or a "No transactions found." message if empty. |
+| `showOverallSummary(double income, double expense)`  | Prints total income, total expense, and net balance.                                                       |
+| `showMonthlySummary(double income, double expense)`  | Prints the same fields for a specific month's totals.                                                      |
+| `showCategorySummary(String category, double total)` | Prints the total for a single category between dividers.                                                   |
+| `showHelp()`                                         | Prints the full command reference menu.                                                                    |
+| `showWelcomeMessage()`                               | Prints the ASCII art banner followed by the welcome prompt.                                                |
+| `showExitMessage()`                                  | Prints the goodbye message on exit.                                                                        |
+
+ANSI colour codes are used for the input prompt (`ANSI_YELLOW`) and the welcome banner
+(`ANSI_BRIGHT_GREEN`), with `ANSI_RESET` applied after each coloured block. A 60-character
+underscore `DIVIDER` is used to visually separate output sections.
 ### Transaction
 
 The `Transaction` class is the abstract base class shared by all transaction types in the application.
@@ -35,11 +114,11 @@ declares the abstract `getType()` method that each subclass must implement to id
 | `date`        | `LocalDate` | The date of the transaction            |
 
 All fields are declared `protected final`, making them accessible to subclasses but immutable after construction.
-This immutability is intentional — rather than modifying a transaction in place, the `EditCommand` removes
+This immutability is intentional: rather than modifying a transaction in place, the `EditCommand` removes
 the old transaction and inserts a newly constructed one at the same index.
 
 **Abstract method:**
-- `getType()` — returns a lowercase string identifying the transaction type (e.g. `"income"` or `"expense"`).
+- `getType()`: returns a lowercase string identifying the transaction type (e.g. `"income"` or `"expense"`).
   This is used by `SummaryCommand` to distinguish income from expense entries without relying on `instanceof` checks.
 
 ## Expense Class
@@ -66,8 +145,8 @@ Logging is configured at `WARNING` level to reduce noise during normal operation
 convention used by `Income` and `TransactionList`.
 
 ### Key Methods
-- `getType()` — returns `"expense"`, used to distinguish transaction types at runtime without `instanceof` checks.
-- `toString()` — formats the transaction for display
+- `getType()`: returns `"expense"`, used to distinguish transaction types at runtime without `instanceof` checks.
+- `toString()`: formats the transaction for display
   (e.g. `[Expense] food "lunch" $12.50 (2026-03-20)`). The description is omitted from the output
   if it is an empty string, keeping the display clean for transactions logged without a description.
 
@@ -127,7 +206,7 @@ written to disk using the same temp-file-then-move pattern as `Storage`.
   no other way to receive it. Dependency injection would require changes across the entire
   constructor chain.
 - **Built-ins are never written to disk:** Only user-added categories go into `categories.txt`.
-  Built-ins are implicitly protected — `removeCustomCategory` only searches the custom set,
+  Built-ins are implicitly protected, `removeCustomCategory` only searches the custom set,
   so built-ins always return `false`.
 
 ---
@@ -204,7 +283,7 @@ During execution, the method iterates through the current list, comparing the ta
 The following sequence diagram illustrates the precise object interactions when a user searches for a keyword.
 ![Find Sequence Diagram](diagrams/FindSequenceDiagram.png)
 
-### Summarizing Transactions
+### Summarising Transactions
 The `summary` command is handled by the `SummaryCommand` class. 
 It performs computations over the list of transactions. 
 It iterates through the entire `TransactionList`, categorising each entry as either an Income or an Expense, and sums the respective totals before calculating the net balance.
@@ -219,11 +298,11 @@ Both commands adhere to the application's Command pattern structure. The diagram
 ![Find and Summary Class Diagram](diagrams/FindSummaryClassDiagram.png)
 
 ### Design Considerations
-* **Case-Insensitive Searching:** For the `find` feature, it was decided that keyword matching should be case-insensitive (e.g., searching "food" returns "Food" and "FOOD"). This greatly enhances user experience, as users do not need to remember the exact capitalization of their previous entries.
+* **Case-Insensitive Searching:** For the `find` feature, it was decided that keyword matching should be case-insensitive (e.g., searching "food" returns "Food" and "FOOD"). This greatly enhances user experience, as users do not need to remember the exact capitalisation of their previous entries.
 * **Stream-Based Indexing:** A major design consideration was how to display matching transactions alongside their original indices from the main list. Instead of iterating through the list and keeping a separate counter, IntStream.range(0, list.size()) was used.
 
 ### Alternatives Considered
-* **Alternative for Summary:** We considered caching the total income and expense values inside `TransactionList`, updating them dynamically every time an item is added or deleted. While this makes the `summary` command run in O(1) time, it heavily complicates the `add` and `delete` operations and introduces state-synchronization bugs. The O(N) calculation upon execution was chosen for stability and simplicity.
+* **Alternative for Summary:** We considered caching the total income and expense values inside `TransactionList`, updating them dynamically every time an item is added or deleted. While this makes the `summary` command run in O(1) time, it heavily complicates the `add` and `delete` operations and introduces state-synchronisation bugs. The O(N) calculation upon execution was chosen for stability and simplicity.
 
 ### Future Improvements
 * **Time-Bound Summaries:** Upgrading the `summary` command to accept date parameters, allowing users to see summaries for specific months or weeks (e.g., `summary /from 2026-01-01 /to 2026-01-31`).
@@ -256,15 +335,15 @@ The following sequence diagram illustrates the interaction when a user sorts tra
   throws a `MoneyBagProMaxException`.
 - **Comparator selection:** `SortCommand.execute()` uses a `switch` statement to build the
   appropriate comparator:
-  - `date` — `Comparator.comparing(Transaction::getDate)` (ascending, earliest first)
-  - `amount` — `Comparator.comparingDouble(Transaction::getAmount).reversed()` (descending,
+  - `date`: `Comparator.comparing(Transaction::getDate)` (ascending, earliest first)
+  - `amount`: `Comparator.comparingDouble(Transaction::getAmount).reversed()` (descending,
     largest first)
-  - `category` — `Comparator.comparing(Transaction::getCategory, String.CASE_INSENSITIVE_ORDER)`
+  - `category`: `Comparator.comparing(Transaction::getCategory, String.CASE_INSENSITIVE_ORDER)`
     (alphabetical, case-insensitive)
 - **Non-mutating:** `TransactionList.getSortedList()` copies the list into a new `ArrayList`,
   sorts the copy using `Collections.sort()`, and returns it. The original `TransactionList` is
   never modified. `SortCommand` does not override `isMutating()`, so it inherits `false` from
-  the base `Command` class — no auto-save is triggered after execution.
+  the base `Command` class, no auto-save is triggered after execution.
 
 ### Class Diagram
 ![Sort Class Diagram](diagrams/SortClassDiagram.png)
@@ -279,7 +358,7 @@ The following sequence diagram illustrates the interaction when a user sorts tra
   sign errors. The standard library comparators are well-tested and handle edge cases (e.g., null
   dates) more robustly.
 - **`isMutating()` returns false:** Because the original list is unchanged, no storage save is
-  needed after sort. This is an intentional contract with the main loop — sort is a view command,
+  needed after sort. This is an intentional contract with the main loop, sort is a view command,
   not a data command.
 
 ### Alternatives Considered
@@ -290,7 +369,7 @@ The following sequence diagram illustrates the interaction when a user sorts tra
 - **Caching the sorted result:** Storing the last sort result in `TransactionList` could avoid
   re-sorting on repeated calls. However, any add/delete/edit operation would stale the cache,
   requiring cache-invalidation logic. Since the list is small for a personal finance app and
-  sorting is O(n log n), this optimization was deemed unnecessary.
+  sorting is O(n log n), this optimisation was deemed unnecessary.
 - **Persistent sort order:** An alternative was to make sort permanently reorder the list and
   save to storage. This was rejected because users expect sort to be a display-only operation,
   not a data mutation. Making it persistent would also conflict with undo/redo index semantics.
@@ -363,7 +442,7 @@ The following sequence diagram illustrates the interactions when a user edits a 
 ### Alternatives Considered
 - **Delegating to `DeleteCommand` + `AddCommand`:** Composing an edit from an existing delete
   followed by an add would reuse existing logic, but would push two actions onto the undo stack
-  instead of one — meaning the user would need to undo twice to revert a single edit. The
+  instead of one, meaning the user would need to undo twice to revert a single edit. The
   dedicated `EditCommand` with `recordEdit()` keeps the undo stack accurate.
 
 ### Future Improvements
@@ -405,10 +484,10 @@ The following diagram shows the full interaction when a user redoes a previously
   `ActionPair` capturing the action type, the affected transaction(s), and the list index,
   then clears the redo stack to invalidate any future redo history.
 - **ActionPair:** An inner static class of `UndoRedoManager` that stores:
-  - `ActionType` enum (`ADD`, `DELETE`, `EDIT`)
-  - `transaction` — the transaction that was added/deleted, or the new version after an edit
-  - `oldTransaction` — the previous version before an edit (null for ADD and DELETE)
-  - `index` — the position in the list at the time the action was performed
+  - `ActionType`: enum (`ADD`, `DELETE`, `EDIT`)
+  - `transaction`: the transaction that was added/deleted, or the new version after an edit
+  - `oldTransaction`: the previous version before an edit (null for ADD and DELETE)
+  - `index`: the position in the list at the time the action was performed
 - **Undo logic:** `UndoCommand.execute()` calls `getUndoAction()`, which pops from the undo
   stack and pushes onto the redo stack. The command then switches on the action type to perform
   the inverse operation:
@@ -431,7 +510,7 @@ The following diagram shows the full interaction when a user redoes a previously
 - **Dual-stack delta vs. Memento pattern:** The Memento pattern stores a complete copy of the
   entire `TransactionList` before each mutating action. While straightforward, this uses O(n)
   memory per recorded action, where n is the list size. The dual-stack approach stores only the
-  delta — the action type, one or two transaction objects, and an index — using O(1) memory per
+  delta, the action type, one or two transaction objects, and an index, using O(1) memory per
   action. For a personal finance app where sessions may involve many operations, the delta approach
   is more memory-efficient.
 - **Clearing the redo stack on new action:** When a new mutating action occurs after one or more
@@ -439,7 +518,7 @@ The following diagram shows the full interaction when a user redoes a previously
   editors: branching redo history (where redo could replay an action conflicting with newer
   changes) is avoided by discarding the redo stack. The result is a linear, predictable history.
 - **Index-based reinsertion:** Storing the exact list index allows transactions to be restored to
-  their original position. This is correct because undo/redo is strictly LIFO — the most recent
+  their original position. This is correct because undo/redo is strictly LIFO, the most recent
   action must be undone before earlier ones, which guarantees that stored indices remain valid
   during sequential undo/redo sequences.
 - **Non-persistent history:** Undo/redo stacks are in-memory only and cleared on application
@@ -459,7 +538,7 @@ The following diagram shows the full interaction when a user redoes a previously
   `UndoRedoManager` and two command classes.
 - **Single list with an index pointer:** Maintain one list of `ActionPair` objects with a
   pointer that moves backward on undo and forward on redo. This is functionally equivalent to
-  the dual-stack approach but is less intuitive conceptually — the dual-stack model maps more
+  the dual-stack approach but is less intuitive conceptually, the dual-stack model maps more
   directly to the standard mental model of "undo history" and "redo history" as separate queues.
 
 ### Future Improvements
@@ -491,8 +570,8 @@ Category validity is enforced via an assertion in the constructor, consistent wi
 Logging is configured at `WARNING` level to reduce noise during normal operation.
 
 ### Key Methods
-- `getType()` — returns `"income"`, used to distinguish transaction types polymorphically at runtime.
-- `toString()` — formats the transaction for display (e.g. `[Income] salary "June paycheck" $3000.00 (2026-06-01)`).
+- `getType()`: returns `"income"`, used to distinguish transaction types polymorphically at runtime.
+- `toString()`: formats the transaction for display (e.g. `[Income] salary "June paycheck" $3000.00 (2026-06-01)`).
 
 ### Design Considerations
 The `Income` and `Expense` classes are intentionally kept symmetric in structure.
@@ -528,7 +607,7 @@ After any command that modifies the list (add, delete, etc.), `Storage.save()` s
 On startup, `load()` ensures the `data/` directory and `transactions.txt` file exist, creating them if necessary.
 It then reads all lines from the file, skipping any that do not begin with the `[TXN]` prefix.
 Each valid line is parsed by `parseLine()` into a key-value map of fields (`type`, `category`, `amount`, `description`, `date`).
-The appropriate `Transaction` subclass — either `Income` or `Expense` — is instantiated and added to the `TransactionList`.
+The appropriate `Transaction` subclass, either `Income` or `Expense`, is instantiated and added to the `TransactionList`.
 Malformed lines are skipped with a warning rather than halting the application, so a single corrupt entry does not prevent the rest of the data from loading.
 
 ### Sequence Diagram for Save
@@ -547,7 +626,7 @@ This two-step write ensures that a crash or interruption during saving cannot co
 
 ### Design Considerations
 The `Storage` class is decoupled from the command classes and interacts only with `TransactionList`, keeping concerns cleanly separated.
-Atomic saves via a temporary file were chosen to protect data integrity — a partial write leaves the previous file intact.
+Atomic saves via a temporary file were chosen to protect data integrity, a partial write leaves the previous file intact.
 The pipe-delimited `[TXN] | key=value` format is human-readable and easy to extend with new fields without breaking backward compatibility, since fields are parsed by name rather than by position.
 Assertions are used throughout to enforce preconditions such as non-null inputs and positive amounts, consistent with the defensive programming approach used elsewhere in the codebase.
 
@@ -568,7 +647,7 @@ The export feature allows users to export their transaction data to an external 
 Two export formats are supported: CSV (via `CsvExporter`) and TXT (via `TextFileExporter`).
 Both exporters are located in the `seedu.duke.storage` package alongside the `Storage` class.
 
-### CSV Export — `CsvExporter`
+### CSV Export: `CsvExporter`
 `CsvExporter.export(TransactionList list, String outputPath)` iterates over the `TransactionList` and writes a CSV file to the specified output path.
 The first line of the file is always the header row: `date,type,category,description,amount`.
 Each subsequent line corresponds to one transaction, with fields serialized in the same order as the header.
@@ -577,7 +656,7 @@ If the write fails, a `MoneyBagProMaxException` is thrown with the underlying I/
 
 The output is intended for consumption by CSV-compatible programs such as spreadsheet applications, or for data interchange between tools.
 
-### TXT Export — `TextFileExporter`
+### TXT Export: `TextFileExporter`
 `TextFileExporter.export(String outputPath)` copies the existing `data/transactions.txt` file directly to the specified output path using `StandardCopyOption.REPLACE_EXISTING`.
 The output file is in the same pipe-delimited `[TXN]` format used internally by `Storage`, making it suitable for loading into another instance of MoneyBagProMax.
 If the source data file does not exist, a `MoneyBagProMaxException` is thrown. I/O failures during the copy are also surfaced as `MoneyBagProMaxException`.
@@ -589,7 +668,7 @@ This distinction reflects their different purposes: CSV export is for interopera
 Neither exporter modifies any application state, so they do not implement `isMutating()` and do not trigger a save of `transactions.txt`.
 
 ### Alternatives Considered
-A single unified exporter with a format parameter was considered, but rejected because the two exporters have fundamentally different data sources — one reads from memory, the other from disk — making a shared abstraction awkward without adding unnecessary complexity.
+A single unified exporter with a format parameter was considered, but rejected because the two exporters have fundamentally different data sources, one reads from memory, the other from disk, making a shared abstraction awkward without adding unnecessary complexity.
 JSON was considered as an additional export format but was excluded for the same reason as in the storage design: it would require a third-party library dependency.
 
 ### Future Improvements
@@ -616,9 +695,9 @@ The four commands are: `add ... rec/FREQUENCY` (create template), `list-rec` (vi
 ### Architecture and Flow
 
 The feature adds two new packages alongside the existing ones:
-- **Model** — `RecurringTransaction` and `Frequency` in `transaction/`
-- **List** — `RecurringTransactionList` in `transactionlist/`
-- **Commands** — `AddRecurringCommand`, `ListRecurringCommand`, `DeleteRecurringCommand`,
+- **Model**: `RecurringTransaction` and `Frequency` in `transaction/`
+- **List**: `RecurringTransactionList` in `transactionlist/`
+- **Commands**: `AddRecurringCommand`, `ListRecurringCommand`, `DeleteRecurringCommand`,
   `GenerateRecurringCommand` in `command/`
 
 The main application loop (`MoneyBagProMax`) owns a single `RecurringTransactionList` instance.
@@ -648,8 +727,8 @@ and is called by `GenerateRecurringCommand` after each generated entry to advanc
 
 #### Frequency enum
 `Frequency` has three values: `DAILY`, `WEEKLY`, `MONTHLY`. Two methods drive the feature:
-- `fromString(String s)` — case-insensitive parse; throws `MoneyBagProMaxException` for unknown values.
-- `next(LocalDate date)` — advances a date by one period using `LocalDate.plusDays(1)`,
+- `fromString(String s)`: case-insensitive parse; throws `MoneyBagProMaxException` for unknown values.
+- `next(LocalDate date)`: advances a date by one period using `LocalDate.plusDays(1)`,
   `plusWeeks(1)`, or `plusMonths(1)` respectively. This handles month-length differences correctly.
 
 #### RecurringTransactionList
@@ -659,10 +738,10 @@ level, matching the convention used by `TransactionList`.
 
 #### Commands
 
-##### Sequence Diagram — add ... rec/FREQUENCY
+##### Sequence Diagram: add ... rec/FREQUENCY
 ![Add Recurring Sequence Diagram](diagrams/AddRecurringSequenceDiagram.png)
 
-##### Sequence Diagram — gen-rec
+##### Sequence Diagram: gen-rec
 ![Generate Recurring Sequence Diagram](diagrams/GenerateRecurringSequenceDiagram.png)
 
 **AddRecurringCommand** validates the category against `Income.VALID_CATEGORIES`,
@@ -674,7 +753,7 @@ it constructs a `RecurringTransaction` and appends it to `RecurringTransactionLi
 1-based index. If the list is empty it shows an informational message. It does not mutate state.
 
 **DeleteRecurringCommand** removes a template by 1-based index. It validates the index bounds
-and confirms deletion via `Ui`. Crucially, it only removes the template — any `Income` or
+and confirms deletion via `Ui`. Crucially, it only removes the template, any `Income` or
 `Expense` entries that were already generated from the template remain in `TransactionList`.
 `isMutatingRecurring()` returns `true`.
 
@@ -698,8 +777,8 @@ because it writes to both `TransactionList` (regular transactions) and the recur
 
 #### isMutatingRecurring() contract
 The base `Command` class declares `isMutatingRecurring()` returning `false`. Commands that
-modify `RecurringTransactionList` — `AddRecurringCommand`, `DeleteRecurringCommand`, and
-`GenerateRecurringCommand` — override it to return `true`. The main loop then calls
+modify `RecurringTransactionList`: `AddRecurringCommand`, `DeleteRecurringCommand`, and
+`GenerateRecurringCommand`: override it to return `true`. The main loop then calls
 `storage.saveRecurring(recurringList)` only when needed, avoiding redundant disk writes.
 
 #### Storage persistence
@@ -932,38 +1011,140 @@ Possible future enhancements include:
 
 As most university students have a lot on their plate such as studying and keeping up with assignments, we find that university students do not have the time to properly keep track of their spending efficiently.
 
-Hence, this product streamlines the process of monitoring spendings and allows them to focus their efforts on the more important things.
+Hence, this product streamlines the process of monitoring spending and allows them to focus their efforts on the more important things.
 
 ---
 
 ## User Stories
 
-| Version | As ... | I want to ... | So that I can ... |
-|---------|--------|---------------|-------------------|
-| v1.0    | a clumsy typist | receive clear, human-readable error messages when I type a command wrong | know exactly how to fix it |
-| v1.0    | a new user | view a help message listing all available commands | learn how to use the application while using the application |
-| v1.0    | a user | delete a specific transaction quickly using an ID | remove entries that were made by mistake |
-| v1.0    | a user | list all transactions entered so far | review my complete spending history |
-| v1.0    | a user | view a summary of all transactions | review my spending habits |
-| v1.0    | a student | add an expense with amount and category | track my spending quickly |
-| v1.0    | a student | add an income entry | track money coming in (allowance, part-time pay) |
-| v1.0    | a student | store a short description | remember what the transaction was for |
-| v1.0    | a student | automatically record a date (default today) | logging is fast |
-| v2.0    | a student | edit an entry | correct mistakes |
-| v2.0    | a student | see how much budget I have left | know if I can afford extra spending |
-| v2.0    | a forgetful user | search for transactions containing a specific keyword | find a specific entry even if I forgot the date |
-| v2.0    | a student | export my data to a simple text/CSV file | back it up or analyze it elsewhere |
-| v2.0    | a user | see a visual progress bar for my budget | visually see how little money I have left for that month / year |
-| v2.0    | a visual learner | see my expenses grouped by category | understand the distribution of my spending |
+| Version | As ...           | I want to ...                                                            | So that I can ...                                               |
+|---------|------------------|--------------------------------------------------------------------------|-----------------------------------------------------------------|
+| v1.0    | a clumsy typist  | receive clear, human-readable error messages when I type a command wrong | know exactly how to fix it                                      |
+| v1.0    | a new user       | view a help message listing all available commands                       | learn how to use the application while using the application    |
+| v1.0    | a user           | delete a specific transaction quickly using an ID                        | remove entries that were made by mistake                        |
+| v1.0    | a user           | list all transactions entered so far                                     | review my complete spending history                             |
+| v1.0    | a user           | view a summary of all transactions                                       | review my spending habits                                       |
+| v1.0    | a student        | add an expense with amount and category                                  | track my spending quickly                                       |
+| v1.0    | a student        | add an income entry                                                      | track money coming in (allowance, part-time pay)                |
+| v1.0    | a student        | store a short description                                                | remember what the transaction was for                           |
+| v1.0    | a student        | automatically record a date (default today)                              | logging is fast                                                 |
+| v2.0    | a student        | edit an entry                                                            | correct mistakes                                                |
+| v2.0    | a student        | see how much budget I have left                                          | know if I can afford extra spending                             |
+| v2.0    | a forgetful user | search for transactions containing a specific keyword                    | find a specific entry even if I forgot the date                 |
+| v2.0    | a student        | export my data to a simple text/CSV file                                 | back it up or analyze it elsewhere                              |
+| v2.0    | a user           | see a visual progress bar for my budget                                  | visually see how little money I have left for that month / year |
+| v2.0    | a visual learner | see my expenses grouped by category                                      | understand the distribution of my spending                      |
 
 ## Non-Functional Requirements
 
-{Give non-functional requirements}
+- **Performance** — All commands must respond within 1 second for a transaction list of up to 10,000 entries on a modern consumer laptop.
+- **Reliability** — Transaction data must not be corrupted by an interrupted save. The atomic temp-file-then-move write strategy in `Storage` ensures the previous data file is always intact if a write fails mid-way.
+- **Portability** — The application must run on Windows, macOS, and Linux without code changes, relying only on the Java 17 standard library and no OS-specific APIs.
+- **Usability** — A user who is comfortable with command-line interfaces should be able to learn all core commands within 10 minutes using only the User Guide.
+- **Maintainability** — Each command must be implemented in its own class. Adding a new command must not require modifying any existing command class.
+- **Data integrity** — Malformed lines in `transactions.txt`, `recurring.txt`, or `categories.txt` must be skipped with a warning rather than crashing the application.
 
 ## Glossary
 
-* *glossary item* - Definition
+* **Transaction**: A single financial record representing either an income or an expense, characterised by a category, amount, optional description, and date.
+* **Income**: A `Transaction` subtype representing money received (e.g. salary, freelance, investment).
+* **Expense**: A `Transaction` subtype representing money spent (e.g. food, transport, rent).
+* **Category**: A label that classifies a transaction. Built-in categories are fixed; custom categories can be added by the user via the `category` command.
+* **Recurring Transaction**: A template that automatically generates `Income` or `Expense` entries on a defined schedule (daily, weekly, or monthly).
+* **Command**: An object that encapsulates a single user action and exposes an `execute()` method; follows the Command design pattern.
+* **Mutating command**: A command that modifies `TransactionList` (e.g. `add`, `delete`, `edit`). These trigger an auto-save after execution.
+* **UndoRedoManager**: The component responsible for tracking the history of mutating commands and enabling their reversal (`undo`) or reapplication (`redo`).
+* **Parser**: The component that converts raw user input strings into `Command` objects.
+* **Storage**: The component responsible for persisting transactions, recurring templates, and custom categories to disk and reloading them on startup.
+* **REPL**: Read-Evaluate-Print Loop; the main application loop that repeatedly reads a command, executes it, and prints the result.
 
 ## Instructions for manual testing
 
-{Give instructions on how to do a manual product testing e.g., how to load sample data to be used for testing}
+The following test cases cover the main features of MoneyBagProMax. Run them in order within a single session unless stated otherwise.
+
+#### Prerequisites
+- Java 17 installed.
+- A clean run with no existing `data/` directory (delete it if present) so tests start from an empty state.
+- Launch the application with `java -jar MoneyBagProMax.jar`.
+
+---
+
+#### Adding transactions
+1. `add food/12.50 desc/lunch d/2026-01-15` — expect confirmation showing a food expense of $12.50.
+2. `add salary/3000 desc/jan pay d/2026-01-01` — expect confirmation showing a salary income of $3000.00.
+3. `add food/999999999` — expect an error for an amount that exceeds the allowed limit.
+4. `add unknown/10` — expect an error for an unrecognised category.
+5. `add food/10 d/not-a-date` — expect an error for an invalid date format; the transaction should **not** be added.
+
+#### Listing transactions
+1. `list` — expect both transactions from steps 1–2 displayed with indices 1 and 2.
+
+#### Finding transactions
+1. `find lunch` — expect only the food transaction from step 1.
+2. `find 2026-01` — expect both transactions (both dated January 2026).
+3. `find zzz` — expect an empty result with no match message.
+
+#### Filtering transactions
+1. `filter from/2026-01-01 to/2026-01-14` — expect only the salary transaction (Jan 1).
+2. `filter from/2026-01-15 to/2026-01-15` — expect only the food transaction (Jan 15).
+3. `filter from/2026-03-01 to/2026-03-31` — expect an empty result.
+4. `filter from/2026-01-01` — expect an error for a missing `to/` parameter.
+
+#### Sorting transactions
+1. `sort by/amount` — expect salary ($3000) listed before food ($12.50).
+2. `sort by/date` — expect salary (Jan 1) listed before food (Jan 15).
+3. `sort by/category` — expect food before salary (alphabetical).
+4. `sort by/invalid` — expect an error for an unrecognised sort criterion.
+5. `list` — expect the original insertion order unchanged by previous sort commands.
+
+#### Editing transactions
+1. `edit 1 food/20 desc/dinner d/2026-01-15` — expect the first transaction replaced; confirm before/after display.
+2. `edit 99 food/10` — expect an error for an out-of-range index.
+
+#### Deleting transactions
+1. `delete 2` — expect the salary transaction removed; `list` should show only one entry.
+2. `delete 99` — expect an error for an out-of-range index.
+
+#### Undo and redo
+1. `undo` — expect the deleted salary transaction restored.
+2. `undo` — expect the edit from step 19 reversed (food/12.50 restored).
+3. `redo` — expect the edit reapplied.
+4. `redo` — expect the delete to be reapplied.
+5. `redo` — expect an error indicating no further redo history.
+
+#### Summary
+1. `add food/12.50 desc/lunch d/2026-01-15` — re-add a food transaction so the list is non-trivial.
+2. `summary all` — expect total income, total expense, and net balance displayed.
+3. `summary expense` — expect total expenses only.
+4. `summary food` — expect only food category total.
+
+#### Budget
+1. `budget set 500` — expect confirmation that the monthly budget is set to $500.
+2. `budget status` — expect monthly budget, current-month expenses, remaining, and percentage used.
+3. `budget set -100` — expect an error for a non-positive budget amount.
+
+#### Statistics
+1. `stats` — expect a full statistics summary including highest/lowest expense, most frequent category, average per category, spending trend, and budget usage.
+
+#### Custom categories
+1. `category add/groceries` — expect confirmation that the category was added.
+2. `add groceries/30 desc/weekly shop` — expect a groceries expense added successfully.
+3. `category remove/groceries` — expect an error because the category is in use by a transaction.
+4. `delete 3` (or whichever index the groceries transaction is) — delete it first.
+5. `category remove/groceries` — expect the category removed successfully.
+6. `category list` — expect only built-in categories listed.
+
+#### Recurring transactions
+1. `add food/10 desc/daily lunch d/2026-01-01 rec/daily` — expect a recurring template created.
+2. `list-rec` — expect the template listed with index 1.
+3. `gen-rec` — expect daily lunch entries generated from 2026-01-01 up to today added to `TransactionList`.
+4. `gen-rec` — run again; expect no new transactions added (already up to date).
+5. `delete-rec 1` — expect the template removed; `list-rec` should show empty.
+
+#### Export
+1. `export-csv ./test-export.csv` — expect a CSV file created at the given path; open it and verify the header row and transaction rows match the current list.
+2. `export-data ./test-backup.txt` — expect the raw data file copied to the given path.
+
+#### Persistence (cross-session)
+1. `exit` — close the application.
+2. Relaunch with `java -jar MoneyBagProMax.jar` — expect all transactions from the previous session still present in `list`.


### PR DESCRIPTION
- Replace Acknowledgements placeholder with proper credits (Duke, AB3, Java docs, PlantUML, CS2113 teaching team)
- Replace NFR, Glossary, and Manual Testing placeholders with real content
- Document Parser, Command, and Ui components based on actual source code
- Add error handling documentation for invalid date input in Parser, including known misleading error message bug

Closes #169, closes #166, closes #165, closes #164, closes #146, closes #156 