### PR TITLE
fix: add missing category, export-csv, and export-data commands to help menu

### DIFF
--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -61,7 +61,7 @@ public class Ui {
                 8. Edit        : `edit [INDEX] [category]/PRICE [desc/DESCRIPTION] [d/YYYY-MM-DD]`
                                  - Replaces a transaction at INDEX with the new values.
                                  - Same category/price/desc/date format as `add`.
-                                 - Example: edit 3 food/20 desc/dinner d/2026-03-20                 
+                                 - Example: edit 3 food/20 desc/dinner d/2026-03-20
                 9. Undo        : `undo`
                                  - Reverses the last add or delete action.
                 10. Redo        : `redo`
@@ -92,7 +92,19 @@ public class Ui {
                                  - Generates all due recurring transactions up to today.
                 17. Filter     : `filter [from/YYYY-MM-DD] [to/YYYY-MM-DD]`
                                  - Filters your transactions based on the time frame given
-                18. Exit       : `exit`
+                18. Category   : `category add/NAME` or `category remove/NAME` or `category list`
+                                 - Manages custom expense categories.
+                                 - `category add/NAME` adds a new custom category.
+                                 - `category remove/NAME` removes a custom category.
+                                 - `category list` lists all available categories.
+                                 - Example: category add/groceries
+                19. Export CSV : `export-csv FILEPATH`
+                                 - Exports all transactions to a .csv file.
+                                 - Example: export-csv ~/transactions.csv
+                20. Export Data: `export-data FILEPATH`
+                                 - Copies the internal data file to a specified location.
+                                 - Example: export-data ~/backup/transactions.txt
+                21. Exit       : `exit`
                                  - Exits the program.
                 %s""".formatted(separator, separator, separator);
 
@@ -164,16 +176,16 @@ public class Ui {
     public static void printWelcomeBanner() {
         System.out.print(ANSI_BRIGHT_GREEN);
         System.out.print("""
-                    .___.        
-                   /     \\       
-                  |       |      
-                  `-.   .-`      
-                 /   \\ /   \\     
-                |   $$$$$   |    
-                |  $$$$$$$  |    
-                |   $$$$$   |    
-                 \\         /     
-                  `-------`      
+                    .___.
+                   /     \\
+                  |       |
+                  `-.   .-`
+                 /   \\ /   \\
+                |   $$$$$   |
+                |  $$$$$$$  |
+                |   $$$$$   |
+                 \\         /
+                  `-------`
             """);
         System.out.print(ANSI_RESET);
     }

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -123,7 +123,19 @@ Enter a command: ============================================================
                  - Generates all due recurring transactions up to today.
 17. Filter     : `filter [from/YYYY-MM-DD] [to/YYYY-MM-DD]`
                  - Filters your transactions based on the time frame given
-18. Exit       : `exit`
+18. Category   : `category add/NAME` or `category remove/NAME` or `category list`
+                 - Manages custom expense categories.
+                 - `category add/NAME` adds a new custom category.
+                 - `category remove/NAME` removes a custom category.
+                 - `category list` lists all available categories.
+                 - Example: category add/groceries
+19. Export CSV : `export-csv FILEPATH`
+                 - Exports all transactions to a .csv file.
+                 - Example: export-csv ~/transactions.csv
+20. Export Data: `export-data FILEPATH`
+                 - Copies the internal data file to a specified location.
+                 - Example: export-data ~/backup/transactions.txt
+21. Exit       : `exit`
                  - Exits the program.
 ============================================================
 


### PR DESCRIPTION
- Add category command entry covering add/NAME, remove/NAME, and list
- Add export-csv command entry with filepath usage example
- Add export-data command entry with filepath usage example
- Renumber exit from 18 to 21

Closes #161 