### PR TITLE
fix: Reject extra arguments for undo and redo commands

### DIFF
--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -84,8 +84,14 @@ public class Parser {
         case "sort":
             return parseSortCommand(arguments);
         case "undo":
+            if (!arguments.isEmpty()) {
+                throw new MoneyBagProMaxException("undo does not take any arguments.");
+            }
             return new UndoCommand(undoRedoManager);
         case "redo":
+            if (!arguments.isEmpty()) {
+                throw new MoneyBagProMaxException("redo does not take any arguments.");
+            }
             return new RedoCommand(undoRedoManager);
         case "edit":
             return parseEditCommand(arguments);


### PR DESCRIPTION
## Summary
- `undo <args>` now throws an error instead of silently ignoring extra arguments (fixes #181)
- `redo <args>` now throws an error instead of silently ignoring extra arguments (fixes #183)

Single change in `Parser.java`: added `arguments.isEmpty()` guard before constructing `UndoCommand` and `RedoCommand`.