### PR TITLE
Fix stats spending trend

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -945,6 +945,14 @@ For example, TransactionList provides methods such as:
 - getAverageSpendingPerCategory()
 - getSpendingTrend()
 
+The spending trend is computed by grouping expense transactions by month using YearMonth.
+TransactionList aggregates the total expense for each month and compares the earliest and latest months.
+
+If the total expense in the later month is higher than the earlier month, the trend is reported as Increasing.
+If it is lower, the trend is reported as Decreasing.
+If both are equal, the trend is reported as Stable.
+
+If expense data exists for fewer than two distinct months, the application reports "Not enough data" to avoid misleading results.
 The implementation also uses HashMap to compute category frequency and average spending per category efficiently.
 
 To reduce duplication, a helper method was introduced to generalise the logic for finding extreme transactions (e.g. highest or lowest transactions of a certain type).  
@@ -966,6 +974,7 @@ StatsCommand requests a series of values from TransactionList, including total i
 If a budget has been set, StatsCommand also retrieves the current month’s total expense from TransactionList and passes it to Budget to calculate the percentage of budget used.
 
 Finally, StatsCommand formats the information into a statistics summary and passes it to Ui for display.
+The spending trend is derived from monthly aggregated expense data and is only computed when at least two distinct months of expense data are available.
 
 ### Design Considerations
 
@@ -991,12 +1000,21 @@ It also makes the code clearer for tasks such as finding the most frequent categ
 Option 1 was chosen because it reduces code duplication and improves maintainability.  
 The helper method hides the repeated filtering and comparison logic while still exposing a clear public API through methods such as getHighestExpense() and getLowestExpense().
 
+#### Aspect: How to compute spending trend
+
+- Option 1 (Chosen): Compare expense totals across distinct months.
+- Option 2: Split transactions based on list position.
+
+Option 1 was chosen because it reflects actual time-based spending behaviour.
+Using list position can produce misleading results when transactions are not evenly distributed over time, especially when all expenses fall within the same month.
+
 ### Future Improvements
 Possible future enhancements include:
 - adding category-specific statistics such as stats CATEGORY
 - allowing users to request statistics for a specified month
 - comparing statistics across months
 - presenting more detailed trend analysis
+- extending spending trend analysis to support multi-month comparisons or custom date ranges
 
 ---
 

--- a/src/main/java/seedu/duke/command/DeleteCommand.java
+++ b/src/main/java/seedu/duke/command/DeleteCommand.java
@@ -24,6 +24,10 @@ public class DeleteCommand extends Command {
 
         int listIndex = targetIndex - 1;
 
+        if (list.isEmpty()) {
+            throw new MoneyBagProMaxException("There are no entries in the list to delete.");
+        }
+
         if (listIndex < 0 || listIndex >= list.size()) {
             throw new MoneyBagProMaxException("Invalid transaction index. " +
                     "Please provide a number between 1 and " + list.size() + ".");

--- a/src/main/java/seedu/duke/transactionlist/TransactionList.java
+++ b/src/main/java/seedu/duke/transactionlist/TransactionList.java
@@ -4,6 +4,7 @@ import seedu.duke.transaction.Transaction;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -181,26 +182,24 @@ public class TransactionList {
     }
 
     public String getSpendingTrend() {
-        if (transactions.size() < 2) {
-            return "Not enough data";
-        }
-
-        double earlier = 0;
-        double later = 0;
-
-        YearMonth firstMonth = YearMonth.from(transactions.get(0).getDate());
-        YearMonth lastMonth = YearMonth.from(transactions.get(transactions.size() - 1).getDate());
+        Map<YearMonth, Double> monthTotals = new HashMap<>();
 
         for (Transaction t : transactions) {
             if (t.getType().equals("expense")) {
-                YearMonth tMonth = YearMonth.from(t.getDate());
-                if (tMonth.equals(firstMonth)) {
-                    earlier += t.getAmount();
-                } else if (tMonth.equals(lastMonth)) {
-                    later += t.getAmount();
-                }
+                YearMonth month = YearMonth.from(t.getDate());
+                monthTotals.put(month, monthTotals.getOrDefault(month, 0.0) + t.getAmount());
             }
         }
+
+        if (monthTotals.size() < 2) {
+            return "Not enough data";
+        }
+
+        YearMonth earliest = Collections.min(monthTotals.keySet());
+        YearMonth latest = Collections.max(monthTotals.keySet());
+
+        double earlier = monthTotals.get(earliest);
+        double later = monthTotals.get(latest);
 
         if (later > earlier) {
             return "Increasing";

--- a/src/test/java/seedu/duke/command/DeleteCommandTest.java
+++ b/src/test/java/seedu/duke/command/DeleteCommandTest.java
@@ -12,6 +12,7 @@ import seedu.duke.undoredo.UndoRedoManager;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DeleteCommandTest {
 
@@ -91,5 +92,17 @@ public class DeleteCommandTest {
         DeleteCommand command = new DeleteCommand(1, undoRedoManager);
 
         assertThrows(MoneyBagProMaxException.class, () -> command.execute(list, budget, ui));
+    }
+
+    @Test
+    void execute_emptyList_throwsEmptyListMessage() {
+        DeleteCommand command = new DeleteCommand(1, undoRedoManager);
+
+        MoneyBagProMaxException exception = assertThrows(
+                MoneyBagProMaxException.class,
+                () -> command.execute(list, budget, ui)
+        );
+
+        assertTrue(exception.getMessage().contains("There are no entries in the list to delete"));
     }
 }

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -151,7 +151,7 @@ class ParserTest {
         String input = "filter from/31-12-2026 to/2026-12-31";
 
         MoneyBagProMaxException exception = assertThrows(MoneyBagProMaxException.class, () -> parser.parse(input));
-        assertTrue(exception.getMessage().contains("Invalid date format — expected YYYY-MM-DD."));
+        assertTrue(exception.getMessage().contains("Invalid date format"));
     }
 
     @Test

--- a/src/test/java/seedu/duke/transactionlist/TransactionListTest.java
+++ b/src/test/java/seedu/duke/transactionlist/TransactionListTest.java
@@ -3,6 +3,9 @@ package seedu.duke.transactionlist;
 import org.junit.jupiter.api.Test;
 import seedu.duke.transaction.Expense;
 import seedu.duke.transaction.Transaction;
+
+import java.time.LocalDate;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -136,5 +139,41 @@ public class TransactionListTest {
         list.remove(1);
 
         assertEquals(expense3, list.get(1));
+    }
+
+    @Test
+    void getSpendingTrend_sameMonthExpenses_returnsNotEnoughData() {
+        TransactionList list = new TransactionList();
+        list.add(new Expense("food", 10.0, "", LocalDate.of(2026, 4, 10)));
+        list.add(new Expense("transport", 20.0, "", LocalDate.of(2026, 4, 10)));
+
+        assertEquals("Not enough data", list.getSpendingTrend());
+    }
+
+    @Test
+    void getSpendingTrend_laterMonthHigher_returnsIncreasing() {
+        TransactionList list = new TransactionList();
+        list.add(new Expense("food", 10.0, "", LocalDate.of(2026, 3, 10)));
+        list.add(new Expense("transport", 30.0, "", LocalDate.of(2026, 4, 10)));
+
+        assertEquals("Increasing", list.getSpendingTrend());
+    }
+
+    @Test
+    void getSpendingTrend_laterMonthLower_returnsDecreasing() {
+        TransactionList list = new TransactionList();
+        list.add(new Expense("food", 40.0, "", LocalDate.of(2026, 3, 10)));
+        list.add(new Expense("transport", 10.0, "", LocalDate.of(2026, 4, 10)));
+
+        assertEquals("Decreasing", list.getSpendingTrend());
+    }
+
+    @Test
+    void getSpendingTrend_equalMonthTotals_returnsStable() {
+        TransactionList list = new TransactionList();
+        list.add(new Expense("food", 20.0, "", LocalDate.of(2026, 3, 10)));
+        list.add(new Expense("transport", 20.0, "", LocalDate.of(2026, 4, 10)));
+
+        assertEquals("Stable", list.getSpendingTrend());
     }
 }

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -50,9 +50,9 @@ Enter a command: Deleted: [Expense] food "lunch" $10.00 (2025-03-01)
 
 Enter a command: Deleted: [Expense] food $10.00 (2025-03-01)
 
-Enter a command: [ERROR!] Invalid transaction index. Please provide a number between 1 and 0.
+Enter a command: [ERROR!] There are no entries in the list to delete.
 
-Enter a command: [ERROR!] Invalid transaction index. Please provide a number between 1 and 0.
+Enter a command: [ERROR!] There are no entries in the list to delete.
 
 Enter a command: [ERROR!] Invalid, try: delete INDEX
 


### PR DESCRIPTION
Fix spending trend logic in stats and update Developer Guide.

- Updated getSpendingTrend() to group expenses by month and compare earliest vs latest month
- Return "Not enough data" when there are fewer than two distinct expense months
- Prevent misleading results such as "Decreasing" when all expenses fall within the same month
- Added/updated tests for spending trend scenarios
- Updated DG to document the improved month-based trend calculation and design considerations

Fixes #152 
Fixes #160 