### PR TITLE
fix: fix CsvExporter newline handling

### DIFF
--- a/src/main/java/seedu/duke/storage/CsvExporter.java
+++ b/src/main/java/seedu/duke/storage/CsvExporter.java
@@ -19,7 +19,7 @@ public class CsvExporter {
             lines.add("date,type,category,description,amount");
             for (int i = 0; i < list.size(); i++) {
                 Transaction t = list.get(i);
-                lines.add(String.join(",",
+                lines.add(String.join(",", 
                                       escape(t.getDate().toString()),
                                       escape(t.getType()),
                                       escape(t.getCategory()),
@@ -28,7 +28,7 @@ public class CsvExporter {
                 ));
             }
             Path path = Paths.get(outputPath);
-            Files.write(path, lines);
+            Files.writeString(path, String.join(System.lineSeparator(), lines) + System.lineSeparator());
             return path;
         } catch (IOException e) {
             throw new MoneyBagProMaxException("Failed to export CSV: " + e.getMessage());
@@ -39,7 +39,8 @@ public class CsvExporter {
         if (value == null) {
             return "";
         }
-        if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+        value = value.replace("\n", " ").replace("\r", " ");
+        if (value.contains(",") || value.contains("\"")) {
             return "\"" + value.replace("\"", "\"\"") + "\"";
         }
         return value;

--- a/src/test/java/seedu/duke/storage/CsvExporterTest.java
+++ b/src/test/java/seedu/duke/storage/CsvExporterTest.java
@@ -210,4 +210,71 @@ class CsvExporterTest {
         assertNotNull(returned);
         assertTrue(Files.exists(returned));
     }
+
+    @Test
+    void export_veryLargeList_writesAllRows() throws MoneyBagProMaxException, IOException {
+        Files.createDirectories(Paths.get("data"));
+        for (int i = 0; i < 1000; i++) {
+            list.add(new Expense("food", 10.0, "item" + i, LocalDate.of(2026, 3, 23)));
+        }
+        exporter.export(list, OUTPUT_FILE);
+
+        List<String> lines = Files.readAllLines(Paths.get(OUTPUT_FILE));
+        assertEquals(1001, lines.size()); // 1000 rows + header
+    }
+
+    @Test
+    void export_descriptionWithNewline_newlineReplacedWithSpace() throws MoneyBagProMaxException, IOException {
+        Files.createDirectories(Paths.get("data"));
+        list.add(new Expense("food", 10.0, "line1\nline2", LocalDate.of(2026, 3, 23)));
+        exporter.export(list, OUTPUT_FILE);
+
+        List<String> lines = Files.readAllLines(Paths.get(OUTPUT_FILE));
+        assertEquals(2, lines.size());
+        assertTrue(lines.get(1).contains("line1 line2"));
+    }
+
+    @Test
+    void export_veryLargeAmount_writesCorrectly() throws MoneyBagProMaxException, IOException {
+        Files.createDirectories(Paths.get("data"));
+        list.add(new Expense("food", Double.MAX_VALUE, "test", LocalDate.of(2026, 3, 23)));
+        exporter.export(list, OUTPUT_FILE);
+
+        List<String> lines = Files.readAllLines(Paths.get(OUTPUT_FILE));
+        assertEquals(2, lines.size());
+        assertTrue(lines.get(1).contains(String.valueOf(Double.MAX_VALUE)));
+    }
+
+    @Test
+    void export_descriptionWithCarriageReturn_handledGracefully() throws MoneyBagProMaxException, IOException {
+        Files.createDirectories(Paths.get("data"));
+        list.add(new Expense("food", 10.0, "line1\rline2", LocalDate.of(2026, 3, 23)));
+        exporter.export(list, OUTPUT_FILE);
+
+        List<String> lines = Files.readAllLines(Paths.get(OUTPUT_FILE));
+        assertEquals(2, lines.size());
+        assertTrue(lines.get(1).contains("line1 line2"));
+    }
+
+    @Test
+    void export_descriptionWithBothQuoteAndComma_escapedCorrectly() throws MoneyBagProMaxException, IOException {
+        Files.createDirectories(Paths.get("data"));
+        list.add(new Expense("food", 10.0, "rice, \"special\"", LocalDate.of(2026, 3, 23)));
+        exporter.export(list, OUTPUT_FILE);
+
+        List<String> lines = Files.readAllLines(Paths.get(OUTPUT_FILE));
+        assertEquals(2, lines.size());
+        assertTrue(lines.get(1).contains("\"rice, \"\"special\"\"\""));
+    }
+
+    @Test
+    void export_amountWithManyDecimalPlaces_writesCorrectly() throws MoneyBagProMaxException, IOException {
+        Files.createDirectories(Paths.get("data"));
+        list.add(new Expense("food", 10.123456789, "test", LocalDate.of(2026, 3, 23)));
+        exporter.export(list, OUTPUT_FILE);
+
+        List<String> lines = Files.readAllLines(Paths.get(OUTPUT_FILE));
+        assertEquals(2, lines.size());
+        assertTrue(lines.get(1).contains("10.123456789"));
+    }
 }

--- a/src/test/java/seedu/duke/storage/StorageTest.java
+++ b/src/test/java/seedu/duke/storage/StorageTest.java
@@ -428,4 +428,42 @@ class StorageTest {
 
         assertEquals(500, loadedBudget.getMonthlyBudget());
     }
+
+    @Test
+    void load_veryLargeTransactionList_allRestored() throws MoneyBagProMaxException {
+        for (int i = 0; i < 1000; i++) {
+            list.add(new Expense("food", 10.0, "item" + i, LocalDate.of(2026, 3, 23)));
+        }
+        storage.save(list, budget);
+
+        TransactionList loaded = new TransactionList();
+        Budget newBudget = new Budget();
+        storage.load(loaded, newBudget);
+
+        assertEquals(1000, loaded.size());
+    }
+
+    @Test
+    void load_descriptionWithPipeCharacter_handledGracefully() throws MoneyBagProMaxException {
+        list.add(new Expense("food", 10.0, "rice | noodles", LocalDate.of(2026, 3, 23)));
+        storage.save(list, budget);
+
+        TransactionList loaded = new TransactionList();
+        Budget newBudget = new Budget();
+        storage.load(loaded, newBudget);
+
+        assertEquals(1, loaded.size());
+    }
+
+    @Test
+    void save_budgetZero_roundTripsCorrectly() throws MoneyBagProMaxException {
+        budget.setMonthlyBudget(0);
+        storage.save(list, budget);
+
+        TransactionList loaded = new TransactionList();
+        Budget loadedBudget = new Budget();
+        storage.load(loaded, loadedBudget);
+
+        assertEquals(0, loadedBudget.getMonthlyBudget());
+    }
 }

--- a/src/test/java/seedu/duke/storage/TextFileExporterTest.java
+++ b/src/test/java/seedu/duke/storage/TextFileExporterTest.java
@@ -112,4 +112,18 @@ class TextFileExporterTest {
 
         assertEquals(original, Files.readString(Paths.get(DATA_FILE)));
     }
+
+    @Test
+    void export_veryLargeSourceFile_copiedCorrectly() throws MoneyBagProMaxException, IOException {
+        Files.createDirectories(Paths.get("data"));
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            sb.append("[TXN] | type=expense | category=food | amount=10.0 | description=lunch | date=2026-03-23\n");
+        }
+        Files.writeString(Paths.get(DATA_FILE), sb.toString());
+
+        exporter.export(OUTPUT_FILE);
+
+        assertEquals(1000, Files.readAllLines(Paths.get(OUTPUT_FILE)).size());
+    }
 }


### PR DESCRIPTION
- Replace embedded newlines and carriage returns with spaces in CsvExporter to prevent malformed CSV rows on all platforms
- Add tests for newline/carriage return in descriptions, combined quote+comma escaping, and decimal amount precision in CsvExporterTest