### PR TITLE
fix: show original indices in sort output to match delete/edit

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -154,7 +154,7 @@ Displays transactions sorted by the specified criterion. The underlying list ord
 
 **Format**: `sort by/CRITERIA`
 
-**Valid criteria:**
+**Valid criteria (case-insensitive):**
 - `date` — ascending (earliest first)
 - `amount` — descending (largest first)
 - `category` — alphabetical A–Z (case-insensitive)
@@ -165,7 +165,7 @@ Displays transactions sorted by the specified criterion. The underlying list ord
 - `sort by/category` — shows all transactions sorted alphabetically by category.
 
 > [!NOTE]
-> Sort does not change the indices used by `delete` and `edit`. Use `list` to see the original insertion order.
+> The index shown next to each transaction in the sorted view is its **original list index** — the same number to use with `delete` and `edit`.
 
 ---
 

--- a/src/main/java/seedu/duke/command/SortCommand.java
+++ b/src/main/java/seedu/duke/command/SortCommand.java
@@ -60,9 +60,9 @@ public class SortCommand extends Command {
         }
 
         List<Transaction> sorted = list.getSortedList(comparator);
-        ui.showMessage("Transactions sorted by " + sortBy + ":");
-        for (int i = 0; i < sorted.size(); i++) {
-            ui.showMessage((i + 1) + ". " + sorted.get(i));
+        ui.showMessage("Transactions sorted by " + sortBy + " (indices match delete/edit):");
+        for (Transaction t : sorted) {
+            ui.showMessage(list.getOriginalIndex(t) + ". " + t);
         }
     }
 }

--- a/src/main/java/seedu/duke/transactionlist/TransactionList.java
+++ b/src/main/java/seedu/duke/transactionlist/TransactionList.java
@@ -101,6 +101,22 @@ public class TransactionList {
     }
 
     /**
+     * Returns the 1-based position of the given transaction in the original insertion-order list.
+     * Uses object identity (==) for the lookup.
+     *
+     * @param t the transaction to find
+     * @return 1-based index, or -1 if not found
+     */
+    public int getOriginalIndex(Transaction t) {
+        for (int i = 0; i < transactions.size(); i++) {
+            if (transactions.get(i) == t) {
+                return i + 1;
+            }
+        }
+        return -1;
+    }
+
+    /**
      * Returns a new list containing all transactions sorted by the given comparator.
      * The original list order is not modified.
      *

--- a/src/test/java/seedu/duke/command/SortCommandTest.java
+++ b/src/test/java/seedu/duke/command/SortCommandTest.java
@@ -46,10 +46,10 @@ class SortCommandTest {
         Command command = new SortCommand("date");
         command.execute(list, budget, ui);
 
-        String expectedOutput = "Transactions sorted by date:" + System.lineSeparator()
-                + "1. [Income] salary \"pay\" $50.00 (2026-03-14)" + System.lineSeparator()
-                + "2. [Expense] transport \"bus\" $5.00 (2026-03-15)" + System.lineSeparator()
-                + "3. [Expense] food \"lunch\" $10.50 (2026-03-16)" + System.lineSeparator();
+        String expectedOutput = "Transactions sorted by date (indices match delete/edit):" + System.lineSeparator()
+                + "2. [Income] salary \"pay\" $50.00 (2026-03-14)" + System.lineSeparator()
+                + "3. [Expense] transport \"bus\" $5.00 (2026-03-15)" + System.lineSeparator()
+                + "1. [Expense] food \"lunch\" $10.50 (2026-03-16)" + System.lineSeparator();
 
         assertEquals(expectedOutput, outContent.toString());
     }
@@ -66,9 +66,9 @@ class SortCommandTest {
         Command command = new SortCommand("amount");
         command.execute(list, budget, ui);
 
-        String expectedOutput = "Transactions sorted by amount:" + System.lineSeparator()
-                + "1. [Income] salary \"pay\" $50.00 (2026-03-14)" + System.lineSeparator()
-                + "2. [Expense] food \"lunch\" $10.50 (2026-03-14)" + System.lineSeparator()
+        String expectedOutput = "Transactions sorted by amount (indices match delete/edit):" + System.lineSeparator()
+                + "2. [Income] salary \"pay\" $50.00 (2026-03-14)" + System.lineSeparator()
+                + "1. [Expense] food \"lunch\" $10.50 (2026-03-14)" + System.lineSeparator()
                 + "3. [Expense] transport \"bus\" $5.00 (2026-03-14)" + System.lineSeparator();
 
         assertEquals(expectedOutput, outContent.toString());
@@ -86,10 +86,10 @@ class SortCommandTest {
         Command command = new SortCommand("category");
         command.execute(list, budget, ui);
 
-        String expectedOutput = "Transactions sorted by category:" + System.lineSeparator()
-                + "1. [Expense] food \"lunch\" $10.50 (2026-03-14)" + System.lineSeparator()
-                + "2. [Income] salary \"pay\" $50.00 (2026-03-14)" + System.lineSeparator()
-                + "3. [Expense] transport \"bus\" $5.00 (2026-03-14)" + System.lineSeparator();
+        String expectedOutput = "Transactions sorted by category (indices match delete/edit):" + System.lineSeparator()
+                + "2. [Expense] food \"lunch\" $10.50 (2026-03-14)" + System.lineSeparator()
+                + "3. [Income] salary \"pay\" $50.00 (2026-03-14)" + System.lineSeparator()
+                + "1. [Expense] transport \"bus\" $5.00 (2026-03-14)" + System.lineSeparator();
 
         assertEquals(expectedOutput, outContent.toString());
     }


### PR DESCRIPTION
Fixes #208

Sort previously displayed items numbered 1..N in sorted order, but `delete` and `edit` use original insertion-order indices. A user who picked index 1 from a sort-by-amount view would delete the wrong item.

Changes:
- `TransactionList.getOriginalIndex(Transaction)` — looks up a transaction's 1-based original position by identity
- `SortCommand` — displays each transaction's original index instead of sorted position; updated header to clarify indices match `delete`/`edit`
- `UserGuide.md` — updated sort note and marked criteria as case-insensitive
- `SortCommandTest` — updated expected output to reflect original indices