### PR TITLE
fix: prevent rec/ inside desc/ value from hijacking add routing

### DIFF
--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -147,7 +147,10 @@ public class Parser {
                     && !CategoryManager.getInstance().isValidExpenseCategory(category)) {
                 throw new MoneyBagProMaxException("Invalid category '" + category + "'.");
             }
-            if (remainder.contains(" rec/")) {
+            String remainderForRecCheck = remainder.contains(" desc/")
+                    ? remainder.substring(0, remainder.indexOf(" desc/"))
+                    : remainder;
+            if (remainderForRecCheck.contains(" rec/")) {
                 Frequency frequency = parseFrequency(remainder);
                 String cleanRemainder = remainder.replaceFirst(" rec/\\S+", "").trim();
                 double amount = parseAmount(cleanRemainder);
@@ -237,10 +240,11 @@ public class Parser {
     /**
      * Extracts the date from the add command remainder string.
      * Returns today's date if the d/ token is absent.
-     * Shows an error message and returns today's date if the format is invalid.
+     * Throws MoneyBagProMaxException if the format is invalid — the transaction is rejected.
      *
      * @param remainder The portion of input after the first slash.
-     * @return The parsed LocalDate, or LocalDate.now() if absent or invalid.
+     * @return The parsed LocalDate, or LocalDate.now() if the d/ token is absent.
+     * @throws MoneyBagProMaxException if a d/ token is present but has an invalid date format.
      */
     private LocalDate parseDate(String remainder) throws MoneyBagProMaxException {
         if (!remainder.contains(" d/")) {


### PR DESCRIPTION
Fixes #211, closes #237

**#211:** `Parser.java` used `remainder.contains(" rec/")` to detect recurring add commands. Since `desc/` values can contain arbitrary text, a description like `send rec/today to friend` matched the check and incorrectly routed to `AddRecurringCommand`, causing the transaction to fail.

Fix: check for `rec/` only in the portion of remainder before any `desc/` token, so description content cannot affect command routing.

**#237:** Verified that the date error message already reads "Transaction not added." (not "Using today's date"). Fixed the stale Javadoc on `parseDate` which incorrectly described the method as returning today's date on invalid input.