### PR TITLE
fix: recurring command error handling and category guard

### DIFF
--- a/src/main/java/seedu/duke/MoneyBagProMax.java
+++ b/src/main/java/seedu/duke/MoneyBagProMax.java
@@ -41,7 +41,7 @@ public class MoneyBagProMax {
         logger.info("Core components: TransactionList, Parser, UndoRedoManager and Ui initialised successfully.");
         ui.showWelcomeMessage();
         try {
-            new GenerateRecurringCommand(recurringList).execute(list, budget, ui);
+            new GenerateRecurringCommand(recurringList, false).execute(list, budget, ui);
             storage.saveRecurring(recurringList);
             storage.save(list, budget);
         } catch (MoneyBagProMaxException e) {

--- a/src/main/java/seedu/duke/command/CategoryCommand.java
+++ b/src/main/java/seedu/duke/command/CategoryCommand.java
@@ -3,6 +3,7 @@ package seedu.duke.command;
 import seedu.duke.budget.Budget;
 import seedu.duke.category.CategoryManager;
 import seedu.duke.transaction.Expense;
+import seedu.duke.transactionlist.RecurringTransactionList;
 import seedu.duke.transactionlist.TransactionList;
 import seedu.duke.ui.Ui;
 import seedu.duke.transaction.Income;
@@ -15,19 +16,23 @@ import seedu.duke.transaction.Income;
  */
 public class CategoryCommand extends Command {
 
-    private final String action; 
+    private final String action;
     private final String name;
+    private final RecurringTransactionList recurringList;
 
     /**
      * Constructor for category command
      * @param action add remove or list
      * @param name name of the category provided, or empty string if category is list
+     * @param recurringList the recurring transaction list to check during category removal
      */
-    public CategoryCommand(String action, String name) {
+    public CategoryCommand(String action, String name, RecurringTransactionList recurringList) {
         assert action != null : "Action must not be null";
         assert name != null : "Name must not be null";
+        assert recurringList != null : "RecurringTransactionList must not be null";
         this.action = action;
         this.name = name;
+        this.recurringList = recurringList;
     }
 
     /**
@@ -60,8 +65,17 @@ public class CategoryCommand extends Command {
                         break;
                     }
                 }
+                if (!inUse) {
+                    for (int i = 0; i < recurringList.size(); i++) {
+                        if (recurringList.get(i).getCategory().equalsIgnoreCase(name)) {
+                            inUse = true;
+                            break;
+                        }
+                    }
+                }
                 if (inUse) {
-                    ui.showMessage("Cannot remove '" + name + "': it is used by existing transactions.");
+                    ui.showMessage("Cannot remove '" + name + "': it is used by existing transactions"
+                            + " or recurring templates.");
                 } else if (cm.removeCustomCategory(name)) {
                     ui.showMessage("Custom category removed: " + name);
                 } else {

--- a/src/main/java/seedu/duke/command/DeleteRecurringCommand.java
+++ b/src/main/java/seedu/duke/command/DeleteRecurringCommand.java
@@ -20,6 +20,9 @@ public class DeleteRecurringCommand extends Command {
 
     @Override
     public void execute(TransactionList list, Budget budget, Ui ui) throws MoneyBagProMaxException {
+        if (recurringList.isEmpty()) {
+            throw new MoneyBagProMaxException("No recurring transactions to delete.");
+        }
         int listIndex = targetIndex - 1;
         if (listIndex < 0 || listIndex >= recurringList.size()) {
             throw new MoneyBagProMaxException(

--- a/src/main/java/seedu/duke/command/GenerateRecurringCommand.java
+++ b/src/main/java/seedu/duke/command/GenerateRecurringCommand.java
@@ -14,10 +14,21 @@ import java.time.LocalDate;
 public class GenerateRecurringCommand extends Command {
 
     private final RecurringTransactionList recurringList;
+    private final boolean showEmptyMessage;
 
+    /** User-invoked constructor — prints status messages when nothing is generated. */
     public GenerateRecurringCommand(RecurringTransactionList recurringList) {
+        this(recurringList, true);
+    }
+
+    /**
+     * @param showEmptyMessage false when called at startup to suppress noise;
+     *                         true when the user explicitly runs gen-rec.
+     */
+    public GenerateRecurringCommand(RecurringTransactionList recurringList, boolean showEmptyMessage) {
         assert recurringList != null : "RecurringTransactionList should not be null";
         this.recurringList = recurringList;
+        this.showEmptyMessage = showEmptyMessage;
     }
 
     @Override
@@ -48,7 +59,7 @@ public class GenerateRecurringCommand extends Command {
             }
         }
 
-        if (generatedCount == 0) {
+        if (generatedCount == 0 && showEmptyMessage) {
             if (recurringList.isEmpty()) {
                 ui.showMessage("No recurring transactions configured.");
             } else {

--- a/src/main/java/seedu/duke/command/GenerateRecurringCommand.java
+++ b/src/main/java/seedu/duke/command/GenerateRecurringCommand.java
@@ -48,8 +48,12 @@ public class GenerateRecurringCommand extends Command {
             }
         }
 
-        if (generatedCount == 0 && !recurringList.isEmpty()) {
-            ui.showMessage("No recurring transactions are due.");
+        if (generatedCount == 0) {
+            if (recurringList.isEmpty()) {
+                ui.showMessage("No recurring transactions configured.");
+            } else {
+                ui.showMessage("No recurring transactions are due.");
+            }
         }
     }
 

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -451,7 +451,7 @@ public class Parser {
 
     private Command parseCategoryCommand(String args) throws MoneyBagProMaxException {
         if (args.equals("list")) {
-            return new CategoryCommand("list", "");
+            return new CategoryCommand("list", "", recurringList);
         }
         if (args.startsWith("add/")) {
             String name = args.substring("add/".length()).trim().toLowerCase();
@@ -462,7 +462,7 @@ public class Parser {
                 throw new MoneyBagProMaxException(
                         "Category name must only contain letters, digits, hyphens, or underscores.");
             }
-            return new CategoryCommand("add", name);
+            return new CategoryCommand("add", name, recurringList);
         }
         if (args.startsWith("remove/")) {
             String name = args.substring("remove/".length()).trim().toLowerCase();
@@ -473,7 +473,7 @@ public class Parser {
                 throw new MoneyBagProMaxException(
                         "Category name must only contain letters, digits, hyphens, or underscores.");
             }
-            return new CategoryCommand("remove", name);
+            return new CategoryCommand("remove", name, recurringList);
         }
         throw new MoneyBagProMaxException(
                 "Invalid category command. Usage:\n"

--- a/src/test/java/seedu/duke/command/CategoryCommandTest.java
+++ b/src/test/java/seedu/duke/command/CategoryCommandTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import seedu.duke.budget.Budget;
 import seedu.duke.category.CategoryManager;
+import seedu.duke.transactionlist.RecurringTransactionList;
 import seedu.duke.transactionlist.TransactionList;
 import seedu.duke.ui.Ui;
 
@@ -26,6 +27,7 @@ class CategoryCommandTest {
 
     private CapturingUi ui;
     private TransactionList list;
+    private RecurringTransactionList recurringList;
     private Budget budget;
 
     @BeforeEach
@@ -36,19 +38,20 @@ class CategoryCommandTest {
 
         ui = new CapturingUi();
         list = new TransactionList();
+        recurringList = new RecurringTransactionList();
         budget = new Budget();
     }
 
     @Test
     void execute_addNewCategory_showsSuccess() {
-        new CategoryCommand("add", "groceries").execute(list, budget, ui);
+        new CategoryCommand("add", "groceries", recurringList).execute(list, budget, ui);
         assertTrue(ui.messages.get(0).contains("added"));
         assertTrue(CategoryManager.getInstance().isValidExpenseCategory("groceries"));
     }
 
     @Test
     void execute_addBuiltInCategory_showsAlreadyBuiltIn() {
-        new CategoryCommand("add", "food").execute(list, budget, ui);
+        new CategoryCommand("add", "food", recurringList).execute(list, budget, ui);
         assertTrue(ui.messages.get(0).contains("built-in"));
         //food cannot be added as a custom category
         assertFalse(CategoryManager.getInstance().getCustomCategories().contains("food"));
@@ -57,34 +60,34 @@ class CategoryCommandTest {
     @Test
     void execute_addDuplicateCustom_showsAlreadyExists() {
         CategoryManager.getInstance().addCustomCategory("hobbies");
-        new CategoryCommand("add", "hobbies").execute(list, budget, ui);
+        new CategoryCommand("add", "hobbies", recurringList).execute(list, budget, ui);
         assertTrue(ui.messages.get(0).contains("already exists"));
     }
     
     @Test
     void execute_removeExistingCustom_showsSuccess() {
         CategoryManager.getInstance().addCustomCategory("hobbies");
-        new CategoryCommand("remove", "hobbies").execute(list, budget, ui);
+        new CategoryCommand("remove", "hobbies", recurringList).execute(list, budget, ui);
         assertTrue(ui.messages.get(0).contains("removed"));
         assertFalse(CategoryManager.getInstance().isValidExpenseCategory("hobbies"));
     }
 
     @Test
     void execute_removeBuiltIn_showsCannotRemove() {
-        new CategoryCommand("remove", "food").execute(list, budget, ui);
+        new CategoryCommand("remove", "food", recurringList).execute(list, budget, ui);
         assertTrue(ui.messages.get(0).contains("Cannot remove"));
     }
 
     @Test
     void execute_removeNonExistent_showsNotFound() {
-        new CategoryCommand("remove", "xyz").execute(list, budget, ui);
+        new CategoryCommand("remove", "xyz", recurringList).execute(list, budget, ui);
         assertTrue(ui.messages.get(0).contains("not found"));
     }
     
     @Test
     void execute_list_showsBuiltInsAndCustom() {
         CategoryManager.getInstance().addCustomCategory("petcare");
-        new CategoryCommand("list", "").execute(list, budget, ui);
+        new CategoryCommand("list", "", recurringList).execute(list, budget, ui);
         String output = ui.messages.get(0);
         assertTrue(output.contains("food"));    // built-in
         assertTrue(output.contains("petcare")); // custom
@@ -92,8 +95,8 @@ class CategoryCommandTest {
 
     @Test
     void isMutating_alwaysFalse() {
-        assertFalse(new CategoryCommand("add", "x").isMutating());
-        assertFalse(new CategoryCommand("remove", "x").isMutating());
-        assertFalse(new CategoryCommand("list", "").isMutating());
+        assertFalse(new CategoryCommand("add", "x", recurringList).isMutating());
+        assertFalse(new CategoryCommand("remove", "x", recurringList).isMutating());
+        assertFalse(new CategoryCommand("list", "", recurringList).isMutating());
     }
 }


### PR DESCRIPTION
Fixes #219, #222, #217

**#219:** `delete-rec` on an empty list produced `"between 1 and 0"`. Now shows `"No recurring transactions to delete."` when the list is empty before hitting the generic range check.

**#222:** `gen-rec` produced blank output when no recurring templates were configured. Now shows `"No recurring transactions configured."` for an empty list (and keeps `"No recurring transactions are due."` when templates exist but none are due).

**#217:** `category remove` only checked the main `TransactionList`, allowing removal of categories still in use by recurring templates — causing silent failures on the next `gen-rec`. `RecurringTransactionList` is now passed to `CategoryCommand` and checked during removal.