### PR TITLE
fix: encoding and documentation fixes for error messages and FAQ

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -394,8 +394,11 @@ Exits the MoneyBagProMax application.
 
 **Q**: How do I transfer my data to another computer?
 
-**A**: Install the MoneyBagProMax application on the new computer and run it once to generate the default data file.
-Then, overwrite the generated data/transactions.txt file with the one from your previous computer to transfer all your information.
+**A**: Install the MoneyBagProMax application on the new computer and run it once to generate the default data files.
+Then, copy all three data files from your previous computer into the `data/` folder on the new one, overwriting the generated files:
+- `data/transactions.txt` — your recorded income and expense entries
+- `data/categories.txt` — your custom expense categories
+- `data/recurring.txt` — your recurring transaction templates
 
 ---
 

--- a/src/main/java/seedu/duke/command/RedoCommand.java
+++ b/src/main/java/seedu/duke/command/RedoCommand.java
@@ -37,7 +37,7 @@ public class RedoCommand extends Command {
             list.remove(action.getIndex());
             list.insert(action.getIndex(), action.getTransaction());
             ui.showMessage("Redo: Reapplied edit at position " + (action.getIndex() + 1)
-                    + " — restored " + action.getTransaction());
+                    + " - restored " + action.getTransaction());
             break;
         default:
             throw new MoneyBagProMaxException("Unknown action type.");

--- a/src/main/java/seedu/duke/command/UndoCommand.java
+++ b/src/main/java/seedu/duke/command/UndoCommand.java
@@ -37,7 +37,7 @@ public class UndoCommand extends Command {
             list.remove(action.getIndex());
             list.insert(action.getIndex(), action.getOldTransaction());
             ui.showMessage("Undo: Reverted edit at position " + (action.getIndex() + 1)
-                    + " — restored " + action.getOldTransaction());
+                    + " - restored " + action.getOldTransaction());
             break;
         default:
             throw new MoneyBagProMaxException("Unknown action type.");

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -128,7 +128,7 @@ public class Parser {
     private Command parseAddCommand(String args) throws MoneyBagProMaxException {
         if (args.startsWith("desc/") || args.startsWith("d/") || args.startsWith("rec/")) {
             throw new MoneyBagProMaxException(
-                    "Invalid format — category/PRICE must come first. "
+                    "Invalid format - category/PRICE must come first. "
                             + "Try: add [category]/PRICE [desc/DESCRIPTION] [d/YYYY-MM-DD]");
         }
         
@@ -251,7 +251,7 @@ public class Parser {
         try {
             return LocalDate.parse(dateToken);
         } catch (DateTimeParseException e) {
-            throw new MoneyBagProMaxException("Invalid date format — expected yyyy-MM-dd. Transaction not added.");
+            throw new MoneyBagProMaxException("Invalid date format - expected yyyy-MM-dd. Transaction not added.");
         }
     }
 
@@ -320,7 +320,7 @@ public class Parser {
         String remainder = parts[1].trim();
         if (remainder.startsWith("desc/") || remainder.startsWith("d/")) {
             throw new MoneyBagProMaxException(
-                    "Invalid format — category/PRICE must come first. "
+                    "Invalid format - category/PRICE must come first. "
                             + "Try: edit INDEX [category]/PRICE [desc/DESCRIPTION] [d/YYYY-MM-DD]");
         }
         String[] categoryAndRest = remainder.split("/", 2);
@@ -409,7 +409,7 @@ public class Parser {
             return new FilterCommand(from, to);
 
         } catch (DateTimeParseException e) {
-            throw new MoneyBagProMaxException("Invalid date format — expected YYYY-MM-DD. "
+            throw new MoneyBagProMaxException("Invalid date format - expected YYYY-MM-DD. "
                     + "Use: filter from/YYYY-MM-DD to/YYYY-MM-DD");
         } catch (IndexOutOfBoundsException e) {
             throw new MoneyBagProMaxException("Missing date values! "

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -21,7 +21,7 @@ Enter a command: Added: [Expense] food "lunch" $10.00 (2025-03-01)
 
 Enter a command: Added: [Expense] food $10.00 (2025-03-01)
 
-Enter a command: [ERROR!] Invalid date format — expected yyyy-MM-dd. Transaction not added.
+Enter a command: [ERROR!] Invalid date format - expected yyyy-MM-dd. Transaction not added.
 
 Enter a command: [ERROR!] Invalid price.
 


### PR DESCRIPTION
Fixes #221, #216, closes #234

**#221:** Em-dash (U+2014) in user-visible strings in `UndoCommand`, `RedoCommand`, and `Parser` caused mojibake (`â€"`) on Windows terminals using code page 1252. Replaced with ASCII ` - ` in all user-facing message strings. `EXPECTED.TXT` updated accordingly.

**#216:** FAQ data-transfer instructions only mentioned `transactions.txt`, causing silent loss of custom categories and recurring templates on the destination computer. Now lists all three files: `transactions.txt`, `categories.txt`, and `recurring.txt`.

**#234:** Sort criteria input is case-insensitive (the parser calls `.toLowerCase()` before matching). The UG now documents this explicitly with "(case-insensitive)" on the criteria label — addressed in PR #240.