### PR TITLE
docs: fix export command examples to use cross-platform paths in UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -55,7 +55,7 @@ respective system [here](https://www.oracle.com/java/technologies/javase/jdk17-a
 
 ## Features
 
-> [!NOTE]
+> [NOTE]
 > ‼️ **Notes about the command format**:
 > - Words in **UPPER_CASE** are placeholders to be supplied by you, the user.
 > - For example: in `delete ENTRY_INDEX`, **ENTRY_INDEX** is a placeholder that should be replaced with the actual index number.
@@ -80,10 +80,10 @@ For managing custom expense categories, see [Managing Custom Categories](#managi
 - `add transport/3.50 desc/bus ride` Adds a transport expense of $3.50 with the description *"bus ride"*, dated today.
 - `add medical/25 desc/checkup d/2026-03-01` Adds a medical expense of $25.00 with the description *"checkup"*, dated 1st March 2026.
 
-> [!NOTE]
+> [NOTE]
 > If the date is omitted, it defaults to today's date. If the description is omitted, the transaction is recorded without one.
 
-> [!NOTE]
+> [NOTE]
 > The expense category input is case-insensitive.
 
 ---
@@ -98,9 +98,9 @@ Adds an income transaction to your list.
 - `add salary/500 desc/allowance d/2026-03-01` Adds a salary income of $500.00 described as *"allowance"* on 1st March 2026.
 - `add freelance/150` Adds a freelance income of $150.00 with today's date and no description.
 
-> [!NOTE] If the date is omitted, it defaults to today's date. If the description is omitted, the transaction is recorded without one.
+> [NOTE] If the date is omitted, it defaults to today's date. If the description is omitted, the transaction is recorded without one.
 
-> [!NOTE]
+> [NOTE]
 > The income category input is case-insensitive.
 
 ---
@@ -113,7 +113,7 @@ Displays all recorded transactions in a numbered list.
 **Examples**:
 - `list` Displays all transactions currently stored in the application.
 
-> [!NOTE]
+> [NOTE]
 > If there are no transactions recorded, the application will show an empty list message instead.
 ---
 
@@ -126,7 +126,7 @@ Searches for transactions that contain a specific keyword in their category, des
 - `find lunch` Searches for all transactions containing the word *"lunch"*.
 - `find 2026-03` Searches for all transactions from March 2026.
 
-> [!NOTE]
+> [NOTE]
 > If no transactions match your keyword, an empty result will be returned.
 
 ---
@@ -145,7 +145,7 @@ Displays overall totals or specific category totals for your transactions.
 - `summary month/2026-03` Shows the total income, expenses, and net balance for that particular month.
 - `summary food month/2026-04` Shows you the total expense for 2026-04.
 
-> [!NOTE]
+> [NOTE]
 > The input category is case-insensitive.
 ---
 
@@ -164,7 +164,7 @@ Displays transactions sorted by the specified criterion. The underlying list ord
 - `sort by/amount` — shows all transactions from highest to lowest amount.
 - `sort by/category` — shows all transactions sorted alphabetically by category.
 
-> [!NOTE]
+> [NOTE]
 > Sort does not change the indices used by `delete` and `edit`. Use `list` to see the original insertion order.
 
 ---
@@ -177,7 +177,7 @@ Deletes the transaction at the specified index in the displayed list.
 **Examples**:
 - `delete 3` Deletes the 3rd transaction in the list.
 
-> [!NOTE]
+> [NOTE]
 > The index must be a valid positive integer corresponding to an existing transaction.
 ---
 
@@ -191,7 +191,7 @@ All fields must be provided — the edit replaces the entire transaction, not in
 - `edit 2 food/15` Replaces the 2nd transaction with a food expense of $15.00, dated today.
 - `edit 1 salary/3000 desc/march pay d/2026-03-01` Replaces the 1st transaction with a salary income of $3000.00 with the description *"march pay"*, dated 1st March 2026.
 
-> [!NOTE]
+> [NOTE]
 > Use `list` first to confirm the index of the transaction you want to edit. The edit can be reversed with `undo`.
 
 ---
@@ -204,7 +204,7 @@ Reverses the last mutating command (`add`, `delete`, or `edit`). Can be called r
 **Examples**:
 - `undo` — reverses the last add, delete, or edit operation.
 
-> [!NOTE]
+> [NOTE]
 > Undo history is reset when you exit the application. Only `add`, `delete`, and `edit` are undoable.
 
 ---
@@ -217,7 +217,7 @@ Re-applies the last undone action. Only available immediately after an `undo`.
 **Examples**:
 - `redo` — re-applies the last undone operation.
 
-> [!NOTE]
+> [NOTE]
 > Performing any new mutating command (`add`/`delete`/`edit`) after an `undo` clears the redo history.
 
 ---
@@ -233,7 +233,7 @@ Allows you to set a monthly budget and check your current budget usage.
 - `budget set 1000` Sets your monthly budget to $1000.
 - `budget status` Displays the current monthly budget, total spent for the month, remaining budget, and percentage used.
 
-> [!NOTE]
+> [NOTE]
 > Budget usage is calculated using expense transactions from the current month only.
 ---
 
@@ -256,7 +256,7 @@ The statistics include:
 **Examples**:
 - `stats` Displays the full statistics summary for all recorded transactions.
 
-> [!NOTE]
+> [NOTE]
 > General statistics are based on all recorded transactions, while budget usage is based on the current month's expenses.
 ---
 ### Managing Custom Categories: `category`
@@ -278,7 +278,7 @@ Custom categories are saved automatically and available across sessions.
 - `category remove/groceries` — deletes the custom category "groceries"
 - `category list` — lists all available expense categories, built-in and custom
 
-> [!NOTE]
+> [NOTE]
 > Built-in categories (`food`, `transport`, `utilities`, `education`, `rent`, `medical`, `misc`) cannot be removed.
 > A category cannot be removed if it is currently used by an existing transaction — delete those transactions first.
 > Once a custom category is added, it can be used with `add` and `edit` just like a built-in category.
@@ -292,7 +292,7 @@ Creates a recurring transaction template. MoneyBagProMax will automatically gene
 - `FREQUENCY` must be one of: `daily`, `weekly`, `monthly` (case-insensitive)
 - `d/YYYY-MM-DD` sets the start date; defaults to today if omitted
 - The category determines whether the entry is an expense or income (same valid categories as `add`)
-> [!NOTE]
+> [NOTE]
 > For valid expense and income categories, see [Adding an Expense](#adding-an-expense-add-expense-category) and [Adding an Income](#adding-an-income-add-income-category).
 
 **Examples**:
@@ -308,7 +308,7 @@ Displays all stored recurring transaction templates with their index, frequency,
 **Examples**:
 - `list-rec` — Lists all recurring transaction templates currently stored.
 
-> [!NOTE]
+> [NOTE]
 > If no recurring templates exist, the application will show an empty-list message.
 
 ---
@@ -333,7 +333,7 @@ Generates all pending transaction entries for every recurring template, up to to
 **Examples**:
 - `gen-rec` — Generates all due recurring transactions for all templates.
 
-> [!NOTE]
+> [NOTE]
 > If all templates are up-to-date, no new transactions are added.
 
 ---
@@ -346,7 +346,7 @@ Filters and displays only the transactions that fall within a specified date ran
 **Examples**:
 - `filter from/2026-01-01 to/2026-03-31` Displays all transactions from 1st January 2026 to 31st March 2026.
 
-> [!NOTE]
+> [NOTE]
 > Both `from/` and `to/` are compulsory.
 
 ---
@@ -359,10 +359,16 @@ Exports all transactions to a `.csv` file for use in external tools like Microso
 **CSV columns**: `date`, `type`, `category`, `description`, `amount`
 
 **Examples**:
-- `export-csv ~/transactions.csv` Exports all transactions to `transactions.csv` in your home directory.
-- `export-csv reports/june.csv` Exports to a `reports/` subfolder.
+- `export-csv transactions.csv` Exports all transactions to `transactions.csv` in the current directory.
+- `export-csv reports/june.csv` Exports to a `reports/` subfolder (relative to current directory).
 
-> [!NOTE]
+> [NOTE]
+> Use relative paths (e.g. `transactions.csv`) or absolute paths specific to your OS.
+> Tilde (`~/`) expansion is not supported — use the full path instead.
+> - **Windows**: `export-csv C:\Users\YourName\transactions.csv`
+> - **macOS/Linux**: `export-csv /Users/YourName/transactions.csv`
+
+> [NOTE]
 > This is for external analysis only — the CSV cannot be reimported into MoneyBagProMax. For transferring data between devices, use `export-data` instead.
 
 ---
@@ -373,9 +379,15 @@ Copies the internal data file to a location of your choice. Useful for backing u
 **Format**: `export-data FILEPATH`
 
 **Examples**:
-- `export-data ~/backup/transactions.txt` Copies the data file to a backup folder.
+- `export-data backup/transactions.txt` Copies the data file to a `backup/` subfolder in the current directory.
 
-> [!NOTE]
+> [NOTE]
+> Use relative paths or absolute paths specific to your OS.
+> Tilde (`~/`) expansion is not supported — use the full path instead.
+> - **Windows**: `export-data C:\Users\YourName\backup\transactions.txt`
+> - **macOS/Linux**: `export-data /Users/YourName/backup/transactions.txt`
+
+> [NOTE]
 > The exported file can be used to restore your data on another device. See the [FAQ](#faq) for transfer instructions.
 
 ---


### PR DESCRIPTION
- Replace Unix-specific ~/ paths with relative path examples that work on Windows, macOS, and Linux
- Add note clarifying that tilde expansion is not supported
- Add OS-specific absolute path examples for Windows and macOS/Linux

Closes #215 