### PR TITLE
Fix budget formatting, validation and delete help text

### DIFF
--- a/src/main/java/seedu/duke/command/BudgetCommand.java
+++ b/src/main/java/seedu/duke/command/BudgetCommand.java
@@ -30,9 +30,16 @@ public class BudgetCommand extends Command {
             double remaining = budget.calculateRemaining(spent);
             double percent = budget.calculatePercentageUsed(spent);
 
+            String formattedRemaining;
+            if (remaining < 0) {
+                formattedRemaining = String.format("-$%.2f", Math.abs(remaining));
+            } else {
+                formattedRemaining = String.format("$%.2f", remaining);
+            }
+
             ui.showMessage(String.format("Monthly budget: $%.2f", budget.getMonthlyBudget()));
             ui.showMessage(String.format("Spent: $%.2f", spent));
-            ui.showMessage(String.format("Remaining: $%.2f", remaining));
+            ui.showMessage(String.format("Remaining: %s", formattedRemaining));
             ui.showMessage(buildProgressBar(percent));
         }
     }

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -287,6 +287,7 @@ public class Parser {
         }
         String[] parts = args.split(" ", 2);
         String action = parts[0].trim().toLowerCase();
+
         if (action.equals("set")) {
             if (parts.length < 2) {
                 throw new MoneyBagProMaxException("Usage: budget set AMOUNT");
@@ -296,14 +297,19 @@ public class Parser {
                 if (amount <= 0) {
                     throw new MoneyBagProMaxException("Budget must be greater than 0.");
                 }
+                if (amount > 10000000) {
+                    throw new MoneyBagProMaxException("Budget must not exceed 10000000.");
+                }
                 return new BudgetCommand("set", amount);
             } catch (NumberFormatException e) {
                 throw new MoneyBagProMaxException("Invalid budget amount.");
             }
         }
+
         if (action.equals("status")) {
             return new BudgetCommand("status", 0);
         }
+
         throw new MoneyBagProMaxException("Unknown budget command.");
     }
 

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -55,7 +55,7 @@ public class Ui {
                                  - Sorts and displays transactions by the given criteria.
                                  - Valid criteria: `date`, `amount`, `category`
                                  - Example: sort by/date
-                7. Delete      : `delete [ENTRY INDEX]`
+                7. Delete      : `delete ENTRY INDEX`
                                  - Deletes a transaction using its number from the `list`.
                                  - Example: delete 3
                 8. Edit        : `edit [INDEX] [category]/PRICE [desc/DESCRIPTION] [d/YYYY-MM-DD]`

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -191,4 +191,16 @@ class ParserTest {
         Command command = parser.parse("sort  by/date");
         assertInstanceOf(SortCommand.class, command);
     }
+
+    @Test
+    public void parseBudgetCommand_exceedsMaximum_throwsException() {
+        Parser parser = new Parser(new UndoRedoManager(), new RecurringTransactionList());
+
+        MoneyBagProMaxException exception = assertThrows(
+                MoneyBagProMaxException.class,
+                () -> parser.parse("budget set 10000001")
+        );
+
+        assertTrue(exception.getMessage().contains("Budget must not exceed 10000000"));
+    }
 }

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -86,7 +86,7 @@ Enter a command: ============================================================
                  - Sorts and displays transactions by the given criteria.
                  - Valid criteria: `date`, `amount`, `category`
                  - Example: sort by/date
-7. Delete      : `delete [ENTRY INDEX]`
+7. Delete      : `delete ENTRY INDEX`
                  - Deletes a transaction using its number from the `list`.
                  - Example: delete 3
 8. Edit        : `edit [INDEX] [category]/PRICE [desc/DESCRIPTION] [d/YYYY-MM-DD]`


### PR DESCRIPTION
Fix issues related to budget display, validation, and help text formatting.

Budget formatting:
Display negative remaining budget as -$X instead of $-X when over budget

Budget validation:
Enforce upper bound for budget values (max 10,000,000)
Reject invalid inputs with appropriate error messages

Help text:
Correct delete command format from "delete [ENTRY_INDEX]" to "delete ENTRY_INDEX"

Testing:
Added parser test for exceeding budget maximum
Verified correct formatting and validation through manual testing

Fixes #213 
Fixes #225 
Fixes #230 